### PR TITLE
fix(#5): hide ⌘K hint + tighten CTA row below 600px

### DIFF
--- a/site.css
+++ b/site.css
@@ -228,6 +228,12 @@ body { margin: 0; min-height: 100vh; }
   .hero h1 { font-size: 56px; line-height: 60px; }
   .hero { padding: 56px 0 48px; }
 }
+@media (max-width: 600px) {
+  /* hint is the lowest-value CTA — hide so primary + secondary read on one row */
+  .cta-hint { display: none; }
+  .hero-ctas { gap: 8px; }
+  .cta { padding: 10px 14px; font-size: 12.5px; }
+}
 
 /* terminal (404) */
 .term {


### PR DESCRIPTION
## Summary
- On narrow screens, `selected work → · get in touch · or press ⌘K` wrapped to three lines.
- Hint is the lowest-value item (keyboard shortcuts don't apply on touch) — hide below 600px so primary + secondary sit together.
- Also tightens gap and CTA padding below 600px so the row doesn't feel crammed.

## Test plan
- [ ] At ≥601px: row unchanged, hint visible
- [ ] At 600px: hint hidden, two CTAs on one row
- [ ] At 375px (iPhone SE): still one row, readable

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)