### PR TITLE
polish(#6): smooth cmdk open transition + aria-hidden correctness

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@
   </div>
 
   <!-- command palette -->
-  <div id="cmdk" class="cmdk-overlay" role="dialog" aria-modal="true" aria-label="Command palette">
+  <div id="cmdk" class="cmdk-overlay" role="dialog" aria-modal="true" aria-hidden="true" aria-label="Command palette">
     <div class="cmdk" role="combobox" aria-expanded="true">
       <input id="cmdk-input" type="text" placeholder="type a route, command, or `chai`…" autocomplete="off" spellcheck="false" aria-label="Command input">
       <div id="cmdk-results" class="cmdk-results" role="listbox"></div>

--- a/site.css
+++ b/site.css
@@ -94,9 +94,28 @@ body { margin: 0; min-height: 100vh; }
 .vs-handle:hover { color: var(--accent); border-color: var(--accent); }
 
 /* cmdk */
-.cmdk-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.6); backdrop-filter: blur(4px); display: none; align-items: flex-start; justify-content: center; padding-top: 18vh; z-index: 100; }
-.cmdk-overlay.open { display: flex; }
-.cmdk { width: min(640px, 92vw); background: var(--bg-raise); border: 1px solid var(--line-strong); box-shadow: 0 8px 32px rgba(0,0,0,0.48); }
+.cmdk-overlay {
+  position: fixed; inset: 0; background: rgba(0,0,0,0.6); backdrop-filter: blur(4px);
+  display: flex; align-items: flex-start; justify-content: center; padding-top: 18vh; z-index: 100;
+  opacity: 0; visibility: hidden; pointer-events: none;
+  transition: opacity 120ms var(--ease-out), visibility 0s linear 120ms;
+}
+.cmdk-overlay.open {
+  opacity: 1; visibility: visible; pointer-events: auto;
+  transition: opacity 120ms var(--ease-out), visibility 0s;
+}
+.cmdk {
+  width: min(640px, 92vw); background: var(--bg-raise); border: 1px solid var(--line-strong);
+  box-shadow: 0 8px 32px rgba(0,0,0,0.48);
+  transform: translateY(-6px) scale(0.985);
+  transition: transform 160ms var(--ease-out);
+}
+.cmdk-overlay.open .cmdk { transform: translateY(0) scale(1); }
+@media (prefers-reduced-motion: reduce) {
+  .cmdk-overlay, .cmdk-overlay.open, .cmdk, .cmdk-overlay.open .cmdk {
+    transition: none !important; transform: none !important;
+  }
+}
 .cmdk input { width: 100%; background: transparent; border: 0; outline: 0; padding: 14px 16px; font-family: var(--font-mono); font-size: 14px; color: var(--fg); border-bottom: 1px solid var(--line); }
 .cmdk-results { max-height: 320px; overflow-y: auto; }
 .cmdk-row { display: flex; justify-content: space-between; padding: 10px 16px; font-family: var(--font-mono); font-size: 13px; color: var(--fg-muted); cursor: pointer; }

--- a/site.js
+++ b/site.js
@@ -71,7 +71,7 @@
     if (!document.getElementById('cmdk')) {
       const cm = document.createElement('div');
       cm.id = 'cmdk'; cm.className = 'cmdk-overlay';
-      cm.setAttribute('role', 'dialog'); cm.setAttribute('aria-modal', 'true'); cm.setAttribute('aria-label', 'Command palette');
+      cm.setAttribute('role', 'dialog'); cm.setAttribute('aria-modal', 'true'); cm.setAttribute('aria-hidden', 'true'); cm.setAttribute('aria-label', 'Command palette');
       cm.innerHTML = '<div class="cmdk" role="combobox" aria-expanded="true">' +
         '<input id="cmdk-input" type="text" placeholder="type a route, command, or `chai`…" autocomplete="off" spellcheck="false" aria-label="Command input">' +
         '<div id="cmdk-results" class="cmdk-results" role="listbox"></div>' +
@@ -462,13 +462,16 @@
 
   function openCmdk() {
     overlay.classList.add('open');
+    overlay.setAttribute('aria-hidden', 'false');
     sel = 0;
     input.value = '';
     render();
-    setTimeout(() => input.focus(), 0);
+    // defer focus until after visibility flip so the browser grants it
+    requestAnimationFrame(() => input.focus());
   }
   function closeCmdk() {
     overlay.classList.remove('open');
+    overlay.setAttribute('aria-hidden', 'true');
   }
 
   function run(item) {


### PR DESCRIPTION
## Summary
- Cmdk no longer pops in abruptly. Overlay fades 120ms (opacity + visibility), inner panel rides in with a 6px translateY + subtle scale — reads as chrome, not a modal.
- Fixes a real a11y bug while we're here: \`aria-hidden\` now flips true/false on open/close, so screen readers stop announcing the dialog when it's not visible.
- \`requestAnimationFrame\` on focus replaces \`setTimeout(0)\` — more reliable post-visibility-flip focus grant.
- \`prefers-reduced-motion\` short-circuits all transitions.

## Test plan
- [ ] ⌘K opens with fade + slight slide; Esc closes with fade
- [ ] Focus lands on input immediately after open
- [ ] Screen reader: palette is silent when closed, announced when open
- [ ] System setting "reduce motion" enabled → instant open, no transition

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)