### PR TITLE
feat(#7): mobile nav with hamburger drawer below 720px

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,16 +34,23 @@
     <nav class="nav" aria-label="primary">
       <div class="nav-left">
         <a href="index.html" class="brand">raghavahuja<span class="caret">_</span></a>
-        <a href="work.html">work</a>
-        <a href="lab.html">lab</a>
-        <a href="notes.html">notes</a>
-        <a href="about.html">about</a>
-        <a href="contact.html">contact</a>
+        <div class="nav-links">
+          <a href="work.html">work</a>
+          <a href="lab.html">lab</a>
+          <a href="notes.html">notes</a>
+          <a href="about.html">about</a>
+          <a href="contact.html">contact</a>
+        </div>
       </div>
       <div class="nav-right">
         <button id="cmdk-trigger" class="nav-search" aria-label="Open command palette">
           <span class="label-chrome">search</span>
           <kbd class="kbd">⌘</kbd><kbd class="kbd">K</kbd>
+        </button>
+        <button class="nav-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-links">
+          <span class="nav-toggle-bar"></span>
+          <span class="nav-toggle-bar"></span>
+          <span class="nav-toggle-bar"></span>
         </button>
       </div>
     </nav>

--- a/site.css
+++ b/site.css
@@ -14,8 +14,9 @@ body { margin: 0; min-height: 100vh; }
 .hairline { border-top: 1px solid var(--line); }
 
 /* nav */
-.nav { display: flex; justify-content: space-between; align-items: center; padding: 20px 0; border-bottom: 1px solid var(--line); }
+.nav { display: flex; justify-content: space-between; align-items: center; padding: 20px 0; border-bottom: 1px solid var(--line); position: relative; }
 .nav-left { display: flex; gap: 28px; align-items: baseline; font-family: var(--font-mono); font-size: 13px; }
+.nav-links { display: flex; gap: 28px; align-items: baseline; }
 .nav-left a { color: var(--fg-muted); text-decoration: none; }
 .nav-left a:hover { color: var(--accent); }
 .nav-left a.active { color: var(--fg); border-bottom: 1px solid var(--accent); padding-bottom: 2px; }
@@ -24,6 +25,55 @@ body { margin: 0; min-height: 100vh; }
 @keyframes blink { 0%,50% { opacity: 1; } 51%,100% { opacity: 0; } }
 .nav-right { display: flex; gap: 8px; align-items: center; }
 .kbd { font-family: var(--font-mono); font-size: 11px; padding: 2px 5px; border: 1px solid var(--line-strong); border-bottom-width: 2px; border-radius: 2px; background: var(--bg-raise); color: var(--fg); }
+
+/* hamburger toggle — hidden at desktop */
+.nav-toggle {
+  display: none;
+  background: transparent; border: 1px solid var(--line);
+  width: 36px; height: 36px;
+  padding: 0; cursor: pointer;
+  flex-direction: column; justify-content: center; align-items: center; gap: 5px;
+  transition: border-color 120ms var(--ease-out);
+}
+.nav-toggle:hover { border-color: var(--accent); }
+.nav-toggle-bar {
+  display: block; width: 16px; height: 1.5px;
+  background: var(--fg-muted);
+  transition: transform 180ms var(--ease-out), opacity 120ms var(--ease-out), background 120ms var(--ease-out);
+  transform-origin: center;
+}
+.nav.open .nav-toggle { border-color: var(--accent); }
+.nav.open .nav-toggle-bar { background: var(--accent); }
+.nav.open .nav-toggle-bar:nth-child(1) { transform: translateY(6.5px) rotate(45deg); }
+.nav.open .nav-toggle-bar:nth-child(2) { opacity: 0; }
+.nav.open .nav-toggle-bar:nth-child(3) { transform: translateY(-6.5px) rotate(-45deg); }
+
+/* mobile drawer */
+@media (max-width: 719px) {
+  .nav-toggle { display: flex; }
+  .nav-links { display: none; }
+  .nav-right .nav-search { display: none; }
+
+  .nav.open .nav-links {
+    display: flex; flex-direction: column; gap: 0;
+    position: absolute; top: 100%; left: 0; right: 0;
+    background: var(--bg-raise);
+    border-bottom: 1px solid var(--line-strong);
+    padding: 8px 24px 16px;
+    z-index: 50;
+    font-size: 15px;
+    box-shadow: var(--shadow-pop);
+  }
+  .nav.open .nav-links a {
+    padding: 12px 0;
+    border-bottom: 1px solid var(--line);
+  }
+  .nav.open .nav-links a:last-child { border-bottom: 0; }
+  .nav.open .nav-links a.active { border-bottom: 1px solid var(--line); color: var(--accent); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .nav-toggle-bar { transition: none !important; }
+}
 
 /* status bar */
 .status-bar { display: flex; justify-content: space-between; align-items: center; padding: 6px 24px; border-bottom: 1px solid var(--line); font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.04em; color: var(--fg-dim); background: var(--bg-sink); }

--- a/site.js
+++ b/site.js
@@ -28,11 +28,16 @@
       navMount.outerHTML = '<nav class="nav" aria-label="primary">' +
         '<div class="nav-left">' +
           '<a href="index.html" class="brand">raghavahuja<span class="caret">_</span></a>' +
-          items.map(([l,h]) => `<a href="${h}"${active===l?' class="active"':''}>${l}</a>`).join('') +
+          '<div class="nav-links">' +
+            items.map(([l,h]) => `<a href="${h}"${active===l?' class="active"':''}>${l}</a>`).join('') +
+          '</div>' +
         '</div>' +
         '<div class="nav-right">' +
           '<button id="cmdk-trigger" class="nav-search" aria-label="Open command palette">' +
             '<span class="label-chrome">search</span><kbd class="kbd">⌘</kbd><kbd class="kbd">K</kbd>' +
+          '</button>' +
+          '<button class="nav-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-links">' +
+            '<span class="nav-toggle-bar"></span><span class="nav-toggle-bar"></span><span class="nav-toggle-bar"></span>' +
           '</button>' +
         '</div>' +
       '</nav>';
@@ -113,6 +118,37 @@
   }
 
   mountChrome();
+
+  // ---------- mobile nav toggle ----------
+  const navEl = document.querySelector('.nav');
+  const navToggle = document.querySelector('.nav-toggle');
+  if (navEl && navToggle) {
+    function setNavOpen(open) {
+      navEl.classList.toggle('open', open);
+      navToggle.setAttribute('aria-expanded', String(open));
+    }
+    navToggle.addEventListener('click', (e) => {
+      e.stopPropagation();
+      setNavOpen(!navEl.classList.contains('open'));
+    });
+    // close on nav link click (before navigation kicks in, fine either way)
+    navEl.querySelectorAll('.nav-links a').forEach((a) => {
+      a.addEventListener('click', () => setNavOpen(false));
+    });
+    // close on outside click
+    document.addEventListener('click', (e) => {
+      if (!navEl.classList.contains('open')) return;
+      if (!navEl.contains(e.target)) setNavOpen(false);
+    });
+    // close on escape
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && navEl.classList.contains('open')) setNavOpen(false);
+    });
+    // close when viewport grows past breakpoint
+    window.addEventListener('resize', () => {
+      if (window.innerWidth >= 720 && navEl.classList.contains('open')) setNavOpen(false);
+    });
+  }
 
   // ---------- clocks ----------
   const clocks = [


### PR DESCRIPTION
## Summary
- Narrow-width nav (6 links + brand + search) was wrapping and felt ragged. Replaced with a clean hamburger + drop-down drawer below 720px.
- Hamburger bars animate to X on open (`rotate` + `translate`), accent-tinted.
- Drawer is absolutely positioned below the nav, full-width, items stacked with dividers.
- Wired every close path: Esc, outside-click, nav-link tap, viewport grows past 720px.
- `prefers-reduced-motion` kills the bar transitions.

## Markup change
- Nav links wrapped in `.nav-links` container on both the inline home nav and the `site.js` `mountChrome()` injector. Single source for the CSS responsive rules.
- New `.nav-toggle` button in `.nav-right` with `aria-expanded` + `aria-controls`.

## Test plan
- [ ] ≥720px: nav unchanged, no hamburger visible
- [ ] <720px: hamburger visible, links hidden
- [ ] Tap hamburger: drawer slides in, bars → X, aria-expanded=true
- [ ] Tap a link: drawer closes before navigation
- [ ] Tap outside drawer: closes
- [ ] Press Esc: closes
- [ ] Rotate phone from portrait to landscape past 720px: drawer closes
- [ ] Screen reader: toggle reads "Menu, expanded" / "collapsed"
- [ ] `prefers-reduced-motion`: bars toggle instantly, no rotate animation

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)