### PR TITLE
feat: folio · vol. iv · no. 4 — full design system + page rebuild

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,29 +3,13 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="404 — not found. Terminal-style fallback.">
-  <meta name="theme-color" content="#15110D">
+  <meta name="description" content="404 — lost the thread.">
+  <meta name="theme-color" content="#0c0c0e">
   <title>404 · raghav ahuja</title>
-      <link rel="preload" href="fonts/InstrumentSerif-Regular.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="fonts/InstrumentSerif-Italic.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="fonts/JetBrainsMono.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="site.css">
-  <link rel="canonical" href="https://raghavahuja.com/404">
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="https://raghavahuja.com/404">
-  <meta property="og:title" content="404 · raghav ahuja">
-  <meta property="og:description" content="Page not found. But you have a terminal.">
-  <meta property="og:image" content="https://raghavahuja.com/og.png">
-  <meta property="og:image:width" content="1200">
-  <meta property="og:image:height" content="630">
-  <meta property="og:site_name" content="raghavahuja.com">
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:site" content="@ahujatries">
-  <meta name="twitter:creator" content="@ahujatries">
-  <meta name="twitter:title" content="404 · raghav ahuja">
-  <meta name="twitter:description" content="Page not found. But you have a terminal.">
-  <meta name="twitter:image" content="https://raghavahuja.com/og.png">
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%22.9em%22 font-size=%2290%22 fill=%22%230070F3%22%3E_%3C/text%3E%3C/svg%3E">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%22.92em%22 font-size=%2290%22 fill=%22%235b8cff%22%3E_%3C/text%3E%3C/svg%3E">
 </head>
 <body data-page="404">
   <script>try { var s = localStorage.getItem('theme'); if (s) document.documentElement.setAttribute('data-theme', s); } catch (e) {}</script>
@@ -36,62 +20,34 @@
     <div id="nav-mount"></div>
 
     <main id="main">
-
-    <section style="padding: 72px 0 40px;">
-      <div class="kicker">erratum · page missing</div>
-      <h1 style="margin-top: 28px; margin-bottom: 24px; font-size: 160px; line-height: 1; letter-spacing: -0.035em;">
-        404<span class="em-serif" style="font-size: 0.4em; vertical-align: super; margin-left: 4px;">*</span>
-      </h1>
-      <p style="font-family: var(--font-display); font-size: 20px; line-height: 1.55; color: var(--fg-muted); max-width: 60ch; margin-bottom: 32px;">
-        <span class="em-serif">*This page doesn't exist.</span> But you have a terminal. Type <code>ls</code> to see what does, or <code>cd work</code> to go back to something real.
-      </p>
-    </section>
-
-    <section class="section" style="padding-top: 0; border-top: 0;">
-      <div id="term" class="term"></div>
-    </section>
-
+      <section class="notfound">
+        <div class="eyebrow">error · 404 · path not found</div>
+        <h1>Lost the<br>thread.</h1>
+        <p class="lead">
+          This page either never existed, was decommissioned, or you're early.
+          Pick a folio and start again.
+        </p>
+        <div class="links">
+          <a href="index.html">index</a>
+          <a href="work.html">work</a>
+          <a href="docs.html">docs</a>
+          <a href="lab.html">lab</a>
+          <a href="notes.html">writing</a>
+          <a href="about.html">about</a>
+          <a href="contact.html">contact</a>
+        </div>
+        <div class="console">
+          <div class="pos">$ curl raghavahuja.com{path}</div>
+          <div>HTTP/2 404</div>
+          <div>x-edition: folio-iv</div>
+          <div>x-mood: searching</div>
+          <div>x-suggestion: try /work</div>
+        </div>
+      </section>
     </main>
 
     <div id="footer-mount"></div>
   </div>
-
-  <script>
-    const term = document.getElementById('term');
-    const lines = [
-      { t: 'out', x: '404 · not found. but you can still poke around.' },
-      { t: 'out', x: 'type `ls` to list routes, `whoami` for a bio, `help` for more.' },
-    ];
-    function render() {
-      term.innerHTML = lines.map(l =>
-        l.t === 'in'
-          ? `<div><span class="tprompt">$&nbsp;</span><span class="tin">${escape(l.x)}</span></div>`
-          : `<div class="tout">${escape(l.x)}</div>`
-      ).join('') +
-      `<div class="tinput-row"><span class="tprompt">$&nbsp;</span><input id="tin" autocomplete="off" spellcheck="false" aria-label="terminal input"></div>`;
-      const inp = document.getElementById('tin');
-      inp.focus();
-      inp.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') { run(inp.value); }
-      });
-    }
-    function escape(s) { return s.replace(/[&<>"']/g, (c) => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c])); }
-    function run(cmd) {
-      const c = cmd.trim().toLowerCase();
-      lines.push({ t: 'in', x: cmd });
-      if (c === 'ls') lines.push({ t: 'out', x: 'work/  lab/  notes/  about  contact  resume.pdf' });
-      else if (c.startsWith('cd ')) { const r = c.slice(3).replace(/\/$/, ''); window.location.href = `${r}.html`; return; }
-      else if (c === 'whoami') lines.push({ t: 'out', x: 'raghav ahuja · design engineer & senior product designer · 13 yrs shipping conversion-critical products. currently at EF education first. solo: arqo (tryarqo.com) + futbolis.live. based in nyc.' });
-      else if (c === 'uname -a') lines.push({ t: 'out', x: 'raghavahuja.com 1.0.0 #a3f2e91 next.js/15 vercel-edge x86_64' });
-      else if (c === 'help') lines.push({ t: 'out', x: 'ls, cd <route>, whoami, uname -a, chai, clear, exit' });
-      else if (c === 'chai') lines.push({ t: 'out', x: '☕ masala chai poured. refreshing.' });
-      else if (c === 'clear') { lines.length = 0; render(); return; }
-      else if (c === 'exit') { window.location.href = 'index.html'; return; }
-      else if (c !== '') lines.push({ t: 'out', x: `command not found: ${cmd}` });
-      render();
-    }
-    render();
-  </script>
 
   <script src="site.js" defer></script>
 </body>

--- a/about.html
+++ b/about.html
@@ -3,18 +3,17 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="raghav ahuja — senior design engineer. Short bio.">
-  <meta name="theme-color" content="#15110D">
+  <meta name="description" content="raghav ahuja — about. Design engineer in Brooklyn, originally from Jamnapaar.">
+  <meta name="theme-color" content="#0c0c0e">
   <title>about · raghav ahuja</title>
-      <link rel="preload" href="fonts/InstrumentSerif-Regular.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="fonts/InstrumentSerif-Italic.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="fonts/JetBrainsMono.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="site.css">
   <link rel="canonical" href="https://raghavahuja.com/about">
-  <meta property="og:type" content="website">
+  <meta property="og:type" content="profile">
   <meta property="og:url" content="https://raghavahuja.com/about">
   <meta property="og:title" content="about · raghav ahuja">
-  <meta property="og:description" content="Design engineer and senior product designer with 13 years shipping conversion-critical products.">
+  <meta property="og:description" content="Design engineer in Brooklyn. Thirteen years shipping end-to-end.">
   <meta property="og:image" content="https://raghavahuja.com/og.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
@@ -23,9 +22,9 @@
   <meta name="twitter:site" content="@ahujatries">
   <meta name="twitter:creator" content="@ahujatries">
   <meta name="twitter:title" content="about · raghav ahuja">
-  <meta name="twitter:description" content="Design engineer and senior product designer with 13 years shipping conversion-critical products.">
+  <meta name="twitter:description" content="Design engineer in Brooklyn. Thirteen years shipping end-to-end.">
   <meta name="twitter:image" content="https://raghavahuja.com/og.png">
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%22.9em%22 font-size=%2290%22 fill=%22%230070F3%22%3E_%3C/text%3E%3C/svg%3E">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%22.92em%22 font-size=%2290%22 fill=%22%235b8cff%22%3E_%3C/text%3E%3C/svg%3E">
 </head>
 <body data-page="about">
   <script>try { var s = localStorage.getItem('theme'); if (s) document.documentElement.setAttribute('data-theme', s); } catch (e) {}</script>
@@ -36,64 +35,53 @@
     <div id="nav-mount"></div>
 
     <main id="main">
+      <div class="folio-strip">folio 06 — about · the long version</div>
 
-<section style="padding: 72px 0 40px; max-width: 64ch;">
-      <div class="kicker">folio 05 — the person</div>
-      <h1 style="margin-top: 28px; margin-bottom: 32px; font-size: 72px; line-height: 1.04;">
-        <span class="em-serif">About.</span>
-      </h1>
-      <p style="font-family: var(--font-display); font-size: 20px; line-height: 1.6; color: var(--fg); margin: 16px 0;">Raghav Ahuja. Design engineer, senior product designer, founder of <a href="case-study.html?slug=jmnpr-labs">JMNPR Labs</a>. Brooklyn. Originally <em>jamnapaar</em>.</p>
-      <p style="font-family: var(--font-display); font-size: 18px; line-height: 1.65; color: var(--fg-muted); margin: 16px 0;">Thirteen years shipping conversion-critical product end-to-end — research, visual system, front-end, back-end, and the decisions that don't make it into tickets. Currently scaling insurance, checkout, and quoting at <strong style="color: var(--fg); font-weight: 400; font-style: italic;">EF Education First</strong>, and building <a href="case-study.html?slug=jmnpr-labs">JMNPR Labs</a> in my evenings.</p>
-      <p style="font-family: var(--font-display); font-size: 18px; line-height: 1.65; color: var(--fg-muted); margin: 16px 0;">The studio is named <em>Jamanapaar</em> — Hindi for <em>Jamuna paar</em>, the other side of the Yamuna. East Delhi, where I grew up, and the side of the river outsiders looked down on. Brooklyn, where I live now, across a different river. Both sides of a river, both the side that had to build its own tools. The studio is named for the posture.</p>
-    </section>
+      <section class="split-2 split-2--big-left">
+        <div style="max-width: 720px;">
+          <h1 class="hero-tall" style="font-size: 80px;">
+            <span class="italic">About,</span><br>
+            in the long form.
+          </h1>
+          <p class="lead" style="margin-top: 28px;">
+            I'm Raghav. I design and build software, mostly tools for people doing creative work.
+            I grew up in Jamnapaar — that's a neighborhood in Delhi most maps misspell — and I've
+            been in Brooklyn for the better part of a decade.
+          </p>
+          <p style="font-family: var(--font-body); font-size: 16px; line-height: 1.75; color: var(--dim); margin-top: 16px;">
+            Thirteen years in. The first half was design — agency, in-house, brand, product.
+            Around 2019 I started writing the code I was specifying, and I never stopped.
+            Today I work as a senior product designer at EF Education First by day, and I run
+            JMNPR Labs on every other hour. Arqo was a weekend.
+          </p>
+          <p style="font-family: var(--font-body); font-size: 16px; line-height: 1.75; color: var(--dim); margin-top: 12px;">
+            I cook a lot. I read more screenwriting than is sensible. I think the best designers
+            I know read more than they draw.
+          </p>
 
-    <section class="section" style="max-width: 72ch;">
-      <div class="kicker" style="margin-bottom: 20px;">what I care about</div>
-      <ul style="font-family: var(--font-display); font-size: 18px; line-height: 1.6; color: var(--fg-muted); padding-left: 0; list-style: none;">
-        <li style="padding: 10px 0 10px 28px; position: relative; border-bottom: 1px dashed var(--line-soft);"><span style="position: absolute; left: 4px; top: 10px; color: var(--accent);">§</span><strong style="color: var(--fg); font-weight: 400; font-style: italic;">Craft over feature-count.</strong> The tool that does one thing beautifully beats the tool that does nine things grudgingly.</li>
-        <li style="padding: 10px 0 10px 28px; position: relative; border-bottom: 1px dashed var(--line-soft);"><span style="position: absolute; left: 4px; top: 10px; color: var(--accent);">§</span><strong style="color: var(--fg); font-weight: 400; font-style: italic;">Self-serve over sales.</strong> Price it, ship it, let the work sell itself. Sales motion kills catalog velocity.</li>
-        <li style="padding: 10px 0 10px 28px; position: relative; border-bottom: 1px dashed var(--line-soft);"><span style="position: absolute; left: 4px; top: 10px; color: var(--accent);">§</span><strong style="color: var(--fg); font-weight: 400; font-style: italic;">Global from day one.</strong> PPP pricing. Multiple languages. The creator in Jakarta and the creator in Jamnapaar are not an afterthought.</li>
-        <li style="padding: 10px 0 10px 28px; position: relative; border-bottom: 1px dashed var(--line-soft);"><span style="position: absolute; left: 4px; top: 10px; color: var(--accent);">§</span><strong style="color: var(--fg); font-weight: 400; font-style: italic;">AI amplifies, never authors.</strong> Every tool respects the human's voice. No one-click generation of human creative work. Ever.</li>
-        <li style="padding: 10px 0 10px 28px; position: relative;"><span style="position: absolute; left: 4px; top: 10px; color: var(--accent);">§</span><strong style="color: var(--fg); font-weight: 400; font-style: italic;">Standards grow the category.</strong> Publishing open formats and free tools seeds every paid conversation.</li>
-      </ul>
-    </section>
+          <div style="font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--accent); text-transform: lowercase; margin-top: 40px;">§ short list of beliefs</div>
+          <ol class="belief-list">
+            <li>The handoff is a smell.</li>
+            <li>If you can't paginate it, you can't ship it.</li>
+            <li>Speed comes from taste, not from tools.</li>
+            <li>Free tools build careers. Paid tools fund them.</li>
+            <li>The hiring manager wants to see one good thing, not ten okay things.</li>
+          </ol>
+        </div>
 
-    <section class="section" style="max-width: 72ch;">
-      <div class="kicker" style="margin-bottom: 20px;">on JMNPR</div>
-      <p style="font-family: var(--font-display); font-size: 19px; line-height: 1.6; color: var(--fg-muted);">I'm open to a conversation about JMNPR Labs if the right partner or investor reaches out — but the studio is not currently raising. Right now I'm shipping.</p>
-    </section>
-
-    <section class="section" style="max-width: 72ch;">
-      <div class="kicker" style="margin-bottom: 20px;">the toolkit</div>
-      <div style="display: grid; grid-template-columns: 140px 1fr; gap: 14px 32px; font-family: var(--font-mono); font-size: 13px; color: var(--fg-muted);">
-        <span style="color: var(--fg-dim);">design</span><span>figma (advanced) · auto layout · variables · design systems · wcag 2.1 aa</span>
-        <span style="color: var(--fg-dim);">code</span><span>typescript · react · next.js (app router) · react native · tailwind</span>
-        <span style="color: var(--fg-dim);">data</span><span>postgres · supabase · pgvector · liveblocks · yjs</span>
-        <span style="color: var(--fg-dim);">native</span><span>tauri · capacitor · mapbox gl js · fdx xml · pdf gen</span>
-        <span style="color: var(--fg-dim);">ship</span><span>vercel · github actions · lemon squeezy</span>
-        <span style="color: var(--fg-dim);">agentic</span><span>claude code · cursor · v0 · copilot · claude design</span>
-        <span style="color: var(--fg-dim);">research</span><span>qual interviews · usability · experiment design · funnel analysis</span>
-      </div>
-    </section>
-
-    <section class="section" style="max-width: 72ch;">
-      <div class="kicker" style="margin-bottom: 20px;">frameworks I've authored</div>
-      <ul style="font-family: var(--font-display); font-size: 18px; line-height: 1.6; color: var(--fg-muted); padding-left: 20px; list-style: none;">
-        <li style="margin-bottom: 16px; padding-left: 0; position: relative;"><span style="color: var(--accent); margin-right: 8px;">§</span><span style="font-style: italic; color: var(--fg);">Confidence-to-Book (CtB)</span> — a five-stage model plotting where an advisor-assisted prospect sits between curiosity and committed booking. In production use; <a href="docs.html?d=ctb">full writeup →</a></li>
-        <li style="margin-bottom: 16px; padding-left: 0;"><span style="color: var(--accent); margin-right: 8px;">§</span><span style="font-style: italic; color: var(--fg);">MIND</span> — a synthesis method for mixed-method research (mine · inventory · name · decide). Turns a week of interviews into a one-page artefact a team can argue against. <a href="docs.html?d=mind">full writeup →</a></li>
-      </ul>
-    </section>
-
-    <section class="section" style="max-width: 72ch;">
-      <div class="kicker" style="margin-bottom: 20px;">elsewhere</div>
-      <div style="font-family: var(--font-mono); font-size: 14px; color: var(--fg-muted);">
-        <a href="mailto:work.raghavahuja@gmail.com">work.raghavahuja@gmail.com</a> ·
-        <a href="https://github.com/ahujatries">github</a> ·
-        <a href="https://linkedin.com/in/raghav-ahuja">linkedin</a> ·
-        <a href="resume.pdf">resume</a>
-      </div>
-    </section>
-
+        <aside class="side-card">
+          <div class="sc-eyebrow">vital stats</div>
+          <div style="margin-top: 14px;">
+            <div class="sc-row"><span class="k">born</span><span class="v">jamnapaar, delhi</span></div>
+            <div class="sc-row"><span class="k">based</span><span class="v">brooklyn, ny</span></div>
+            <div class="sc-row"><span class="k">title</span><span class="v">design engineer</span></div>
+            <div class="sc-row"><span class="k">day job</span><span class="v">EF education first</span></div>
+            <div class="sc-row"><span class="k">studio</span><span class="v">JMNPR labs</span></div>
+            <div class="sc-row"><span class="k">shipped</span><span class="v">2 apps · 6 essays</span></div>
+            <div class="sc-row"><span class="k">languages</span><span class="v">english, hindi, light spanish</span></div>
+          </div>
+        </aside>
+      </section>
     </main>
 
     <div id="footer-mount"></div>

--- a/case-study.html
+++ b/case-study.html
@@ -4,11 +4,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="raghav ahuja — case study.">
-  <meta name="theme-color" content="#15110D">
+  <meta name="theme-color" content="#0c0c0e">
   <title>case study · raghav ahuja</title>
-  <link rel="preload" href="fonts/InstrumentSerif-Regular.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="fonts/InstrumentSerif-Italic.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="fonts/JetBrainsMono.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="site.css">
   <link rel="canonical" href="https://raghavahuja.com/case-study">
   <meta property="og:type" content="article">
@@ -25,7 +24,7 @@
   <meta name="twitter:title" content="case study · raghav ahuja">
   <meta name="twitter:description" content="Case study from raghav ahuja — design engineer & senior product designer.">
   <meta name="twitter:image" content="https://raghavahuja.com/og.png">
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%22.92em%22 font-size=%2290%22 fill=%22%23E86A4E%22%3E.%3C/text%3E%3C/svg%3E">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%22.92em%22 font-size=%2290%22 fill=%22%235b8cff%22%3E_%3C/text%3E%3C/svg%3E">
 </head>
 <body data-page="work">
   <script>try { var s = localStorage.getItem('theme'); if (s) document.documentElement.setAttribute('data-theme', s); } catch (e) {}</script>

--- a/contact.html
+++ b/contact.html
@@ -3,18 +3,17 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="raghav ahuja — contact. Email, socials, resume.">
-  <meta name="theme-color" content="#15110D">
+  <meta name="description" content="contact raghav ahuja — design engineer & senior product designer.">
+  <meta name="theme-color" content="#0c0c0e">
   <title>contact · raghav ahuja</title>
-      <link rel="preload" href="fonts/InstrumentSerif-Regular.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="fonts/InstrumentSerif-Italic.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="fonts/JetBrainsMono.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="site.css">
   <link rel="canonical" href="https://raghavahuja.com/contact">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://raghavahuja.com/contact">
   <meta property="og:title" content="contact · raghav ahuja">
-  <meta property="og:description" content="Email, GitHub, LinkedIn, résumé — short emails welcomed.">
+  <meta property="og:description" content="The line is open. Same-day replies on weekdays.">
   <meta property="og:image" content="https://raghavahuja.com/og.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
@@ -23,9 +22,9 @@
   <meta name="twitter:site" content="@ahujatries">
   <meta name="twitter:creator" content="@ahujatries">
   <meta name="twitter:title" content="contact · raghav ahuja">
-  <meta name="twitter:description" content="Email, GitHub, LinkedIn, résumé — short emails welcomed.">
+  <meta name="twitter:description" content="The line is open. Same-day replies on weekdays.">
   <meta name="twitter:image" content="https://raghavahuja.com/og.png">
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%22.9em%22 font-size=%2290%22 fill=%22%230070F3%22%3E_%3C/text%3E%3C/svg%3E">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%22.92em%22 font-size=%2290%22 fill=%22%235b8cff%22%3E_%3C/text%3E%3C/svg%3E">
 </head>
 <body data-page="contact">
   <script>try { var s = localStorage.getItem('theme'); if (s) document.documentElement.setAttribute('data-theme', s); } catch (e) {}</script>
@@ -36,50 +35,51 @@
     <div id="nav-mount"></div>
 
     <main id="main">
+      <div class="folio-strip">folio 07 — contact · the line is open</div>
 
-<section style="padding: 72px 0 40px; max-width: 60ch;">
-      <div class="kicker">folio 06 — by mail</div>
-      <h1 style="margin-top: 28px; margin-bottom: 28px; font-size: 72px; line-height: 1.04;">
-        <span class="em-serif">Contact.</span>
-      </h1>
-      <p style="font-family: var(--font-display); font-size: 22px; line-height: 1.55; color: var(--fg); margin-bottom: 16px;">The fastest way to reach me is email.</p>
-      <p style="font-family: var(--font-mono); font-size: 18px; color: var(--accent); margin-bottom: 28px;"><a href="mailto:work.raghavahuja@gmail.com">work.raghavahuja@gmail.com</a></p>
-      <p style="font-family: var(--font-display); font-size: 18px; line-height: 1.6; color: var(--fg-muted);">I reply to everything that isn't a template. If you're a hiring partner, a recruiter, a founder who wants fifteen minutes, a writer who found Arqo and has feedback, or a design engineer who liked one of the tools — you're the inbox.</p>
-    </section>
+      <section class="split-2" style="padding: 64px 0; border-bottom: 1px solid var(--soft-rule);">
+        <div>
+          <h1 class="hero-tall">
+            <span class="italic">Write to me.</span><br>
+            I read every<br>
+            email myself.
+          </h1>
+          <p class="lead">
+            Same-day replies on weekdays. I'm interested in design-engineering roles,
+            studio collaborations, and conversations about ambitious tools for film &amp; writing.
+          </p>
+          <div class="hero-ctas" style="margin-top: 28px;">
+            <a href="mailto:work.raghavahuja@gmail.com" class="cta cta-primary">work.raghavahuja@gmail.com</a>
+            <button class="cta" id="copy-email" type="button">copy →</button>
+          </div>
+        </div>
 
-    <section class="section" style="max-width: 64ch;">
-      <div class="kicker" style="margin-bottom: 16px;">about the work</div>
-      <p style="font-family: var(--font-display); font-size: 18px; line-height: 1.6; color: var(--fg-muted);">For current-role work (EF Education First — insurance, checkout, and the in-house design system tool) email for the case-study password. It unlocks on any device and stays unlocked on the browser for the session.</p>
-    </section>
-
-    <section class="section" style="max-width: 64ch;">
-      <div class="kicker" style="margin-bottom: 16px;">if you're a design partner for JMNPR Labs</div>
-      <p style="font-family: var(--font-display); font-size: 18px; line-height: 1.6; color: var(--fg-muted);">If you're building something that touches creators, filmmaking, design tokens, realtime infra, or standards work — I'd love fifteen minutes. Same email, subject line <code>JMNPR · [your tool]</code> and I'll prioritize it.</p>
-    </section>
-
-    <section class="section" style="max-width: 64ch;">
-      <div class="kicker" style="margin-bottom: 16px;">elsewhere</div>
-      <div style="display: grid; grid-template-columns: 120px 1fr; gap: 14px 32px; font-family: var(--font-mono); font-size: 14px;">
-        <span style="color: var(--fg-dim);">email</span><a href="mailto:work.raghavahuja@gmail.com">work.raghavahuja@gmail.com</a>
-        <span style="color: var(--fg-dim);">github</span><a href="https://github.com/ahujatries">github.com/ahujatries</a>
-        <span style="color: var(--fg-dim);">linkedin</span><a href="https://linkedin.com/in/raghav-ahuja">/in/raghav-ahuja</a>
-        <span style="color: var(--fg-dim);">arqo</span><a href="https://tryarqo.com">tryarqo.com ↗</a>
-        <span style="color: var(--fg-dim);">jmnpr</span><a href="https://jmnpr.com">jmnpr.com ↗</a>
-        <span style="color: var(--fg-dim);">futbolis</span><a href="https://futbolis.live">futbolis.live ↗</a>
-        <span style="color: var(--fg-dim);">resume</span><a href="resume.pdf">resume.pdf ↗</a>
-        <span style="color: var(--fg-dim);">where</span><span style="color: var(--fg);">brooklyn</span>
-      </div>
-
-      <div style="margin-top: 40px; padding-top: 20px; border-top: 1px dashed var(--line); color: var(--fg-dim); font-family: var(--font-mono); font-size: 12px;">
-        or press <kbd class="kbd">⌘K</kbd> and type <code>copy email</code> · <code>open resume</code> · <code>github</code>.
-      </div>
-    </section>
-
+        <aside class="side-card" style="align-self: start;">
+          <div class="sc-eyebrow">elsewhere</div>
+          <div class="elsewhere" style="margin-top: 14px;">
+            <a href="https://github.com/ahujatries"><span class="k">github</span><span>ahujatries →</span></a>
+            <a href="https://linkedin.com/in/raghav-ahuja"><span class="k">linkedin</span><span>in/raghav-ahuja →</span></a>
+            <a href="https://twitter.com/ahujatries"><span class="k">twitter</span><span>@ahujatries →</span></a>
+            <a href="https://threads.net/@ahujatries"><span class="k">threads</span><span>@ahujatries →</span></a>
+            <a href="https://cal.com/raghav"><span class="k">cal</span><span>cal.com/raghav →</span></a>
+          </div>
+          <div class="hc-rule" style="height: 1px; background: var(--rule); margin: 20px 0;"></div>
+          <div class="sc-eyebrow">where</div>
+          <div style="font-family: var(--font-body); font-size: var(--fs-small); color: var(--ink); margin-top: 8px;">brooklyn, ny · open to remote, hybrid bk/nyc, or right offer for relocate.</div>
+        </aside>
+      </section>
     </main>
 
     <div id="footer-mount"></div>
   </div>
 
+  <script>
+    document.getElementById('copy-email')?.addEventListener('click', function () {
+      navigator.clipboard?.writeText('work.raghavahuja@gmail.com');
+      this.textContent = 'copied ✓';
+      setTimeout(() => { this.textContent = 'copy →'; }, 1800);
+    });
+  </script>
   <script src="site.js" defer></script>
 </body>
 </html>

--- a/docs.html
+++ b/docs.html
@@ -4,11 +4,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="raghav ahuja — the library. Frameworks, architecture decision records, and colophon.">
-  <meta name="theme-color" content="#15110D">
+  <meta name="theme-color" content="#0c0c0e">
   <title>the library · raghav ahuja</title>
-  <link rel="preload" href="fonts/InstrumentSerif-Regular.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="fonts/InstrumentSerif-Italic.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="fonts/JetBrainsMono.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="site.css">
   <link rel="canonical" href="https://raghavahuja.com/docs">
   <meta property="og:type" content="website">
@@ -25,7 +24,7 @@
   <meta name="twitter:title" content="the library · raghav ahuja">
   <meta name="twitter:description" content="Frameworks, ADRs, and colophon.">
   <meta name="twitter:image" content="https://raghavahuja.com/og.png">
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%22.92em%22 font-size=%2290%22 fill=%22%23E86A4E%22%3E.%3C/text%3E%3C/svg%3E">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%22.92em%22 font-size=%2290%22 fill=%22%235b8cff%22%3E_%3C/text%3E%3C/svg%3E">
 </head>
 <body data-page="docs">
   <script>try { var s = localStorage.getItem('theme'); if (s) document.documentElement.setAttribute('data-theme', s); } catch (e) {}</script>
@@ -37,14 +36,15 @@
 
     <main id="main">
       <!-- Shelf view (default) -->
-      <section id="view-shelf" style="padding: 72px 0 40px;">
-        <div class="kicker">folio 07 — the library</div>
-        <h1 style="margin-top: 28px; margin-bottom: 24px; max-width: 18ch;">
-          Frameworks, <span class="em-serif">ADRs,</span> &amp; the colophon.
-        </h1>
-        <p style="font-family: var(--font-display); font-size: 20px; line-height: 1.55; color: var(--fg-muted); max-width: 60ch;">
-          A small library. Things I've written to decide something once, so I don't re-decide it every sprint. Pick a spine.
-        </p>
+      <section id="view-shelf">
+        <div class="folio-strip">folio 04 — the library · frameworks, adrs, colophon</div>
+        <div class="page-head">
+          <h1>
+            Frameworks, <span class="em-accent">ADRs,</span><br>
+            &amp; the colophon.
+          </h1>
+          <p class="lead">A small library. Things I've written to decide something once, so I don't re-decide it every sprint. Pick a spine.</p>
+        </div>
       </section>
 
       <section id="shelf-wrap" class="section" style="border-top: 0; padding-top: 0;">

--- a/index.html
+++ b/index.html
@@ -4,11 +4,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="raghav ahuja — design engineer & senior product designer. The code is part of the craft, not a handoff. 13 years shipping conversion-critical products.">
-  <meta name="theme-color" content="#15110D">
+  <meta name="theme-color" content="#0c0c0e">
   <title>raghav ahuja · design engineer &amp; senior product designer</title>
-  <link rel="preload" href="fonts/InstrumentSerif-Regular.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="fonts/InstrumentSerif-Italic.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="fonts/JetBrainsMono.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="site.css">
   <link rel="canonical" href="https://raghavahuja.com/">
   <meta property="og:type" content="website">
@@ -25,7 +24,7 @@
   <meta name="twitter:title" content="raghav ahuja — design engineer & senior product designer">
   <meta name="twitter:description" content="The code is part of the craft, not a handoff. 13 years shipping conversion-critical products.">
   <meta name="twitter:image" content="https://raghavahuja.com/og.png">
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%22.92em%22 font-size=%2290%22 fill=%22%23E86A4E%22%3E.%3C/text%3E%3C/svg%3E">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%22.92em%22 font-size=%2290%22 fill=%22%235b8cff%22%3E_%3C/text%3E%3C/svg%3E">
 </head>
 <body data-page="home">
   <script>
@@ -34,181 +33,116 @@
 
   <a href="#main" class="skip-link">skip to content</a>
 
-  <div id="grid-overlay" class="grid-overlay" aria-hidden="true"></div>
-
-  <!-- status strip — masthead for the night edition -->
-  <div class="status-bar" role="status" aria-live="off">
-    <span class="sb-left"><span class="sb-dot"></span> vol. iv · no. 3 · <span class="em-accent">portfolio · night ed.</span></span>
-    <span class="sb-clocks">
-      <span>jamanapaar <b id="clk-mum">--:--</b></span>
-      <span>brooklyn <b id="clk-nyc">--:--</b></span>
-    </span>
-  </div>
-
   <div class="wrap">
-    <!-- nav -->
-    <nav class="nav" aria-label="primary">
-      <div class="nav-left">
-        <a href="index.html" class="brand">raghav ahuja<span class="caret">.</span></a>
-        <div class="nav-links">
-          <a href="work.html">work</a>
-          <a href="docs.html">docs</a>
-          <a href="lab.html">lab</a>
-          <a href="notes.html">writing</a>
-          <a href="about.html">about</a>
-          <a href="contact.html">contact</a>
-        </div>
-      </div>
-      <div class="nav-right">
-        <button id="cmdk-trigger" class="nav-search" aria-label="Open command palette">
-          <span class="label-chrome">go anywhere</span>
-          <kbd class="kbd">⌘K</kbd>
-        </button>
-        <button class="nav-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-links">
-          <span class="nav-toggle-bar"></span>
-          <span class="nav-toggle-bar"></span>
-          <span class="nav-toggle-bar"></span>
-        </button>
-      </div>
-    </nav>
+    <div id="nav-mount"></div>
 
     <main id="main">
-<!-- hero -->
-      <section class="hero">
-        <div class="eyebrow">folio 01 — the design engineer · read after dark</div>
-        <h1>
-          I design systems, build them, <span class="em-serif">and</span> run the studio behind them.
-        </h1>
-        <p class="sub">
-          The code is part of the craft, not a handoff. Thirteen years shipping end-to-end — research, visual system, front-end, back-end, and the decisions that don't make it into tickets. <a href="case-study.html?slug=arqo">Arqo</a> ships the consumer surface. <a href="case-study.html?slug=jmnpr-labs">JMNPR Labs</a> ships the engine and the free tools. Currently scaling insurance &amp; quoting at EF Education First.
-        </p>
-        <div class="hero-ctas">
-          <a href="work.html" class="cta cta-primary">read the case studies →</a>
-          <a href="mailto:work.raghavahuja@gmail.com" class="cta">get in touch</a>
-          <span class="cta-hint">or press <span class="kbd">⌘K</span></span>
+      <div class="folio-strip">folio 01 — the design engineer · read after dark</div>
+
+      <section class="hero-grid">
+        <div>
+          <h1>
+            I design systems,<br>
+            build them,<br>
+            <span class="em-accent">and run the studio</span><br>
+            behind them.
+          </h1>
+          <p class="lead">
+            The code is part of the craft, not a handoff. Thirteen years shipping end-to-end —
+            research, visual system, front-end, back-end, and the decisions that don't make it into tickets.
+          </p>
+          <div class="hero-ctas">
+            <a href="work.html" class="cta cta-primary">read the case studies →</a>
+            <a href="mailto:work.raghavahuja@gmail.com" class="cta">get in touch</a>
+            <span class="cta-hint">or press <span class="kbd">⌘K</span></span>
+          </div>
         </div>
-        <div class="signal-bar"><div class="signal-fill"></div></div>
+
+        <aside class="hero-card" aria-label="currently shipping">
+          <div class="hc-eyebrow">currently shipping</div>
+          <div class="hc-title">insurance &amp; quoting at EF</div>
+          <div class="hc-rule"></div>
+          <div class="hc-grid">
+            <span class="hc-k">building</span>
+            <span class="hc-v">JMNPR Labs <em>— a one-person studio. Story Kit live, five flagships on deck.</em></span>
+            <span class="hc-k">also</span>
+            <span class="hc-v">Arqo <em>— mobile-first screenwriting, shipped solo in 9 days.</em></span>
+            <span class="hc-k">tooling</span>
+            <span class="hc-v">claude code, cursor, v0 <em>— agentic workflows.</em></span>
+            <span class="hc-k">where</span>
+            <span class="hc-v">brooklyn <em>— jamnapaar, originally.</em></span>
+          </div>
+        </aside>
       </section>
 
-      <!-- ship log (live activity) -->
-      <section class="ship-log" aria-labelledby="shiplog-heading">
-        <button class="vs-handle" data-vs="LiveActivity" title="view source" aria-label="view source">{ }</button>
-        <div class="section-eyebrow">
-          <span id="shiplog-heading">the ship log · updated automatically from git</span>
-          <span class="meta">refreshes every 60s · <span id="tick">loading…</span></span>
+      <section class="highlights" aria-label="recent work">
+        <div class="highlights-head">
+          <span class="label">recent work · curated</span>
+          <a href="work.html">full archive →</a>
         </div>
-        <div class="live-row"><time datetime="2026-04-24" class="date">26·04·24</time><span class="repo">jmnpr/storykit</span><span class="commit-msg">feat: v1.4 worktables export — react-pdf pipeline</span><span class="when">12m ago</span></div>
-        <div class="live-row"><time datetime="2026-04-24" class="date">26·04·24</time><span class="repo">arqo</span><span class="commit-msg">fix: paginator widow suppression on dual dialogue</span><span class="when">2h ago</span></div>
-        <div class="live-row"><time datetime="2026-04-23" class="date">26·04·23</time><span class="repo">jmnpr/fdx</span><span class="commit-msg">feat: lossless round-trip fixtures — writerduet parity</span><span class="when">5h ago</span></div>
-        <div class="live-row"><time datetime="2026-04-23" class="date">26·04·23</time><span class="repo">arqo</span><span class="commit-msg">feat: voice-fingerprint over 777-script library</span><span class="when">1d ago</span></div>
-        <div class="live-row"><time datetime="2026-04-22" class="date">26·04·22</time><span class="repo">raghavahuja.com</span><span class="commit-msg">init: direction A · burnt ink + terracotta · night ed.</span><span class="when">2d ago</span></div>
+        <div class="highlights-grid">
+          <a href="case-study.html?slug=arqo" class="hl-card">
+            <div class="hl-row"><span class="hl-tag">arqo</span><span>26·04</span></div>
+            <div class="hl-title">Voice fingerprint trained on 777 scripts</div>
+            <div class="hl-kind">feature</div>
+          </a>
+          <a href="case-study.html?slug=jmnpr-labs" class="hl-card">
+            <div class="hl-row"><span class="hl-tag">jmnpr/storykit</span><span>26·04</span></div>
+            <div class="hl-title">Worktables export — react-pdf pipeline</div>
+            <div class="hl-kind">release</div>
+          </a>
+          <a href="case-study.html?slug=jmnpr-labs" class="hl-card">
+            <div class="hl-row"><span class="hl-tag">jmnpr/fdx</span><span>26·04</span></div>
+            <div class="hl-title">Lossless round-trip parity with WriterDuet</div>
+            <div class="hl-kind">milestone</div>
+          </a>
+          <a href="notes.html" class="hl-card">
+            <div class="hl-row"><span class="hl-tag">writing</span><span>26·03</span></div>
+            <div class="hl-title">Why I shipped a screenwriting app in 9 days</div>
+            <div class="hl-kind">essay</div>
+          </a>
+        </div>
       </section>
 
-      <!-- now -->
-      <section class="now-block" aria-labelledby="now-heading">
-        <div class="section-eyebrow">
-          <span id="now-heading">what i'm up to · hand-edited</span>
-          <span class="meta">last push · recently</span>
-        </div>
-<div class="now-grid">
-          <div class="now-row"><span class="now-k">shipping</span><span class="now-v">insurance <em>&amp;</em> quoting at EF Education First</span></div>
-          <div class="now-row"><span class="now-k">building</span><span class="now-v">JMNPR Labs <em>— a one-person studio. Story Kit live, five flagships on deck.</em></span></div>
-          <div class="now-row"><span class="now-k">also</span><span class="now-v">Arqo <em>— mobile-first screenwriting app, shipped solo in 9 days</em></span></div>
-          <div class="now-row"><span class="now-k">tooling</span><span class="now-v">claude code, cursor, v0 <em>— agentic workflows</em></span></div>
-          <div class="now-row"><span class="now-k">where</span><span class="now-v">brooklyn <em>— jamnapaar, originally</em></span></div>
-        </div>
-      </section>
-
-      <!-- selected work -->
       <section class="section" aria-labelledby="work-heading">
         <div class="section-head">
           <h2 id="work-heading">Selected work</h2>
           <a href="work.html">index → /work</a>
         </div>
-<a href="case-study.html?slug=arqo" class="work-row">
-          <span class="n">01</span>
-          <div>
-            <h3>Arqo</h3>
-            <p class="sub">A mobile-first, script-led filmmaking tool — shipped solo in 9 days. Custom editor, deterministic paginator, lossless FDX, offline-first, CRDT collab, pgvector voice-tuned AI.</p>
-          </div>
-          <div class="meta">
-            <div>sole design engineer</div>
-            <div>9-day MVP · ongoing</div>
-          </div>
-          <div class="year">2026 →</div>
-        </a>
-        <a href="case-study.html?slug=jmnpr-labs" class="work-row">
-          <span class="n">02</span>
-          <div>
-            <h3>JMNPR Labs</h3>
-            <p class="sub">A one-person studio. Production-grade tools for creators, indie filmmakers, and design engineers. Story Kit live. Five flagships on deck.</p>
-          </div>
-          <div class="meta">
-            <div>founder · design engineer</div>
-            <div>2026 · ongoing</div>
-          </div>
-          <div class="year">2026 →</div>
-        </a>
-        <a href="case-study.html?slug=ef" class="work-row">
-          <span class="n">03</span>
-          <div>
-            <h3>EF Education First <span class="locked-chip">🔒 gated</span></h3>
-            <p class="sub">Insurance, checkout, quoting — and an in-house design system tool supporting three brands across the org. Metrics &amp; specifics behind a password.</p>
-          </div>
-          <div class="meta">
-            <div>senior product designer</div>
-            <div>2022 — present</div>
-          </div>
-          <div class="year">2022 →</div>
-        </a>
+        <div class="work-list">
+          <a href="case-study.html?slug=arqo" class="work-row">
+            <span class="n">01</span>
+            <div>
+              <h3>Arqo</h3>
+              <div class="meta">sole design engineer · 9-day MVP · ongoing</div>
+            </div>
+            <p class="blurb">A mobile-first, script-led filmmaking tool — shipped solo in 9 days. Custom editor, deterministic paginator, lossless FDX, offline-first, CRDT collab, pgvector voice-tuned AI.</p>
+            <div class="year">2026 →</div>
+          </a>
+          <a href="case-study.html?slug=jmnpr-labs" class="work-row">
+            <span class="n">02</span>
+            <div>
+              <h3>JMNPR Labs</h3>
+              <div class="meta">founder · design engineer · 2026 · ongoing</div>
+            </div>
+            <p class="blurb">A one-person studio. Production-grade tools for creators, indie filmmakers, and design engineers. Story Kit live. Five flagships on deck.</p>
+            <div class="year">2026 →</div>
+          </a>
+          <a href="case-study.html?slug=ef" class="work-row">
+            <span class="n">03</span>
+            <div>
+              <h3>EF Education First <span class="locked-chip">🔒 gated</span></h3>
+              <div class="meta">senior product designer · 2022 — present</div>
+            </div>
+            <p class="blurb">Insurance, checkout, quoting — and an in-house design system tool supporting three brands across the org. Metrics &amp; specifics behind a password.</p>
+            <div class="year">2022 →</div>
+          </a>
+        </div>
       </section>
     </main>
 
-    <!-- footer — signed -->
-    <footer class="footer">
-      <div>
-<div class="brand-line">raghav ahuja</div>
-        <div>design engineer · brooklyn</div>
-        <div style="margin-top: 10px;">
-          <a href="mailto:work.raghavahuja@gmail.com">work.raghavahuja@gmail.com</a> ·
-          <a href="https://github.com/ahujatries">github</a> ·
-          <a href="https://linkedin.com/in/raghav-ahuja">linkedin</a> ·
-          <a href="resume.pdf">resume</a>
-        </div>
-      </div>
-      <div class="right">
-        <div class="sign">— written, designed, shipped by one person. night edition.</div>
-        <div style="margin-top: 10px;">set in Instrument Serif &amp; JetBrains Mono</div>
-        <div style="color: var(--fg-dim);">build <span id="build-sha" style="color: var(--accent);">—</span> · <span id="build-deployed">shipped recently</span></div>
-        <div style="color: var(--fg-dim);" id="reader-tz"></div>
-      </div>
-    </footer>
+    <div id="footer-mount"></div>
   </div>
-
-  <!-- command palette -->
-  <div id="cmdk" class="cmdk-overlay" role="dialog" aria-modal="true" aria-hidden="true" aria-label="Command palette">
-    <div class="cmdk" role="combobox" aria-expanded="true">
-      <input id="cmdk-input" type="text" placeholder="go anywhere · type a route, command, or `chai`…" autocomplete="off" spellcheck="false" aria-label="Command input">
-      <div id="cmdk-results" class="cmdk-results" role="listbox"></div>
-      <div class="cmdk-foot">
-        <span><kbd class="kbd">↑↓</kbd> nav</span>
-        <span><kbd class="kbd">↵</kbd> open</span>
-        <span><kbd class="kbd">esc</kbd> close</span>
-        <span id="cmdk-count" style="margin-left:auto;"></span>
-      </div>
-    </div>
-  </div>
-
-  <div id="vs-scrim" class="vs-scrim" aria-hidden="true"></div>
-  <aside id="vs-drawer" class="vs-drawer" aria-hidden="true" aria-label="View source">
-    <div class="vs-head">
-      <span class="label-chrome">view source · <span id="vs-name">component</span></span>
-      <button id="vs-close" class="vs-close" aria-label="Close">esc</button>
-    </div>
-    <pre class="vs-pre"><code id="vs-code"></code></pre>
-  </aside>
-
-  <div id="konami-toast" class="konami-toast" role="status" aria-live="polite" hidden>नमस्ते · crt mode enabled</div>
 
   <script src="site.js" defer></script>
 </body>

--- a/lab.html
+++ b/lab.html
@@ -3,18 +3,17 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="raghav ahuja — lab. Experiments and small pieces.">
-  <meta name="theme-color" content="#15110D">
+  <meta name="description" content="raghav ahuja — lab. Experiments and small pieces, live and decaying.">
+  <meta name="theme-color" content="#0c0c0e">
   <title>lab · raghav ahuja</title>
-      <link rel="preload" href="fonts/InstrumentSerif-Regular.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="fonts/InstrumentSerif-Italic.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="fonts/JetBrainsMono.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="site.css">
   <link rel="canonical" href="https://raghavahuja.com/lab">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://raghavahuja.com/lab">
   <meta property="og:title" content="lab · raghav ahuja">
-  <meta property="og:description" content="Small pieces, loosely joined — experiments in design engineering.">
+  <meta property="og:description" content="Experiments, live and decaying. Sketches that earn their place by being interesting, not finished.">
   <meta property="og:image" content="https://raghavahuja.com/og.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
@@ -23,9 +22,9 @@
   <meta name="twitter:site" content="@ahujatries">
   <meta name="twitter:creator" content="@ahujatries">
   <meta name="twitter:title" content="lab · raghav ahuja">
-  <meta name="twitter:description" content="Small pieces, loosely joined — experiments in design engineering.">
+  <meta name="twitter:description" content="Experiments, live and decaying.">
   <meta name="twitter:image" content="https://raghavahuja.com/og.png">
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%22.92em%22 font-size=%2290%22 fill=%22%23E86A4E%22%3E.%3C/text%3E%3C/svg%3E">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%22.92em%22 font-size=%2290%22 fill=%22%235b8cff%22%3E_%3C/text%3E%3C/svg%3E">
 </head>
 <body data-page="lab">
   <script>try { var s = localStorage.getItem('theme'); if (s) document.documentElement.setAttribute('data-theme', s); } catch (e) {}</script>
@@ -36,76 +35,105 @@
     <div id="nav-mount"></div>
 
     <main id="main">
+      <div class="folio-strip">folio 03 — lab · weird, unfinished, sometimes broken</div>
 
-<section style="padding: 72px 0 40px;">
-      <div class="kicker">folio 03 — the lab</div>
-      <h1 style="margin-top: 28px; margin-bottom: 32px; max-width: 14ch;">
-        <span class="em-serif">Lab.</span>
-      </h1>
-      <p class="sub" style="font-family: var(--font-display); font-size: 20px; line-height: 1.55; color: var(--fg-muted); max-width: 60ch; margin-bottom: 12px;">
-        Smaller things. Weekend builds. Experiments that were too fun not to ship. Some of these became products. Some are just receipts that I build for love, not just for work.
-      </p>
-      <p style="font-family: var(--font-mono); font-size: 11px; color: var(--fg-dim); letter-spacing: 0.08em; text-transform: uppercase; margin-top: 24px;">
-        index → <a href="work.html" style="color: var(--accent);">/work</a> · for bigger projects
-      </p>
-    </section>
+      <section style="padding: 56px 0; border-bottom: 1px solid var(--soft-rule);">
+        <h1 style="font-family: var(--font-display); font-size: 96px; line-height: 0.95; letter-spacing: -0.035em; color: var(--ink); margin: 0;">
+          <span class="italic">The lab.</span><br>
+          Experiments,<br>
+          live and decaying.
+        </h1>
+        <p class="lead" style="margin-top: 24px; max-width: 640px;">
+          Not case studies. Not portfolio. Sketches. Some still work. Some don't.
+          They earn their place by being interesting, not finished.
+        </p>
+      </section>
 
-    <section class="section">
-      <a href="case-study.html?slug=futbolis" class="work-row">
-        <span class="n">01</span>
-        <div>
-          <h3>Futbolis.live</h3>
-          <p class="sub">Visualizing the global pulse of football, one match at a time — 100k concurrent on $19/mo infra. Solo build in 3 weeks, nights and weekends. The infra from this is becoming the JMNPR Realtime Viz Starter.</p>
-        </div>
-        <div class="meta">
-          <div>2026 · 3 weeks · live</div>
-          <div>sole design engineer</div>
-        </div>
-        <div class="year">read full case study →</div>
-      </a>
-      <a href="https://github.com/ahujatries" class="work-row">
-        <span class="n">02</span>
-        <div>
-          <h3>Headway</h3>
-          <p class="sub">Live MTA tracking for individual train cars — per-car stats, real-time positions, the kind of transit viz a subway nerd wishes the MTA shipped. Built for kicks, over a weekend.</p>
-        </div>
-        <div class="meta">
-          <div>2026 · weekend build · live</div>
-          <div>solo</div>
-        </div>
-        <div class="year">open →</div>
-      </a>
-    </section>
+      <div class="lab-grid">
+        <a href="#" class="lab-card span-4 h-280 accent">
+          <svg class="lc-bg" viewBox="0 0 400 200" preserveAspectRatio="xMidYMid slice">
+            <g>
+              <rect x="20" y="30" width="50" height="120" fill="var(--paper)" stroke="var(--rule)"/>
+              <rect x="90" y="30" width="50" height="120" fill="var(--paper)" stroke="var(--rule)"/>
+              <rect x="160" y="30" width="50" height="120" fill="var(--paper)" stroke="var(--accent)" stroke-width="1.5"/>
+              <rect x="230" y="30" width="50" height="120" fill="var(--paper)" stroke="var(--rule)"/>
+              <rect x="300" y="30" width="50" height="120" fill="var(--paper)" stroke="var(--rule)"/>
+            </g>
+          </svg>
+          <div class="lc-foot">
+            <div class="lc-title">Pagination, drawn live</div>
+            <div class="lc-sub">drag a script. watch it paginate per keystroke.</div>
+          </div>
+        </a>
+        <a href="#" class="lab-card span-2 h-280">
+          <svg class="lc-bg" viewBox="0 0 200 200">
+            <circle cx="100" cy="100" r="40" fill="none" stroke="var(--accent)" stroke-width="1">
+              <animate attributeName="r" values="20;80;20" dur="3s" repeatCount="indefinite"/>
+              <animate attributeName="opacity" values="1;0;1" dur="3s" repeatCount="indefinite"/>
+            </circle>
+            <circle cx="100" cy="100" r="3" fill="var(--accent)"/>
+          </svg>
+          <div class="lc-foot">
+            <div class="lc-title">Cursor halo</div>
+            <div class="lc-sub">what if every ui element had ambient awareness?</div>
+          </div>
+        </a>
 
-    <section class="section">
-      <div class="kicker" style="margin-bottom: 20px;">site internals · live on this page</div>
-      <p style="font-family: var(--font-display); font-size: 17px; color: var(--fg-muted); max-width: 60ch; margin-bottom: 24px;">
-        Smaller mechanisms wired into the site itself. Each is a working demo, not a screenshot. The page you're reading is the documentation.
-      </p>
-      <div class="lab-list">
-        <div class="lab-row lab-row--wip">
-          <span class="date">always</span>
-          <span class="title">Grid overlay <span class="wip-tag">hold <code>g</code></span></span>
-          <span class="tag">css · keyboard</span>
-        </div>
-        <div class="lab-row lab-row--wip">
-          <span class="date">always</span>
-          <span class="title">View-source drawer <span class="wip-tag">click <code>{ }</code></span></span>
-          <span class="tag">jsx · drawer</span>
-        </div>
-        <div class="lab-row lab-row--wip">
-          <span class="date">always</span>
-          <span class="title">ASCII chai dispenser <span class="wip-tag">⌘K → <code>chai</code></span></span>
-          <span class="tag">easter</span>
-        </div>
-        <div class="lab-row lab-row--wip">
-          <span class="date">always</span>
-          <span class="title">नमस्ते mode <span class="wip-tag">konami code</span></span>
-          <span class="tag">keyboard · easter</span>
-        </div>
+        <a href="#" class="lab-card span-2 h-220">
+          <div class="lc-foot">
+            <div class="lc-title">∞ horizontal scroll diary</div>
+          </div>
+        </a>
+        <a href="#" class="lab-card span-2 h-220">
+          <div class="lc-bg" style="display: flex; align-items: center; justify-content: center;">
+            <span style="font-family: var(--font-display); font-style: italic; font-size: 110px; color: var(--accent); opacity: 0.4; line-height: 0.9;">aA</span>
+          </div>
+          <div class="lc-foot">
+            <div class="lc-title">text-as-mesh</div>
+            <div class="lc-sub">fraunces, broken into voxels</div>
+          </div>
+        </a>
+        <a href="#" class="lab-card span-2 h-220">
+          <svg class="lc-bg" viewBox="0 0 200 200" preserveAspectRatio="xMidYMid slice">
+            <filter id="grain"><feTurbulence baseFrequency="0.9"/></filter>
+            <rect width="200" height="200" filter="url(#grain)" opacity="0.5"/>
+          </svg>
+          <div class="lc-foot">
+            <div class="lc-title">film grain shader</div>
+            <div class="lc-sub">webgl, runs at 60fps on phones</div>
+          </div>
+        </a>
+
+        <a href="#" class="lab-card span-3 h-220">
+          <div class="lc-bg" style="display: flex;">
+            <div style="flex: 1; background: var(--accent);"></div>
+            <div style="flex: 1; background: var(--ink);"></div>
+            <div style="flex: 1; background: var(--dim);"></div>
+            <div style="flex: 1; background: var(--warn);"></div>
+            <div style="flex: 1; background: var(--pos);"></div>
+          </div>
+          <div class="lc-foot">
+            <div class="lc-title">palette extractor</div>
+            <div class="lc-sub">drag any image, get its 5-color soul</div>
+          </div>
+        </a>
+        <a href="#" class="lab-card span-3 h-220">
+          <div class="lc-bg" style="padding: 20px; font-family: var(--font-mono); font-size: 11px; color: var(--dim); line-height: 1.8;">
+            <div>26·04·26 fix: lab grain on safari</div>
+            <div>26·04·25 feat: cobalt accent, light/dark</div>
+            <div>26·04·24 chore: kill ship-log widget</div>
+            <div style="color: var(--accent);">26·04·23 feat: rebuilt every page</div>
+          </div>
+          <div class="lc-foot">
+            <div class="lc-title">self-hosting changelog</div>
+            <div class="lc-sub">this site's commits, rendered by this site, served by this site</div>
+          </div>
+        </a>
       </div>
-    </section>
 
+      <div style="font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--mute); padding: 24px 0; text-align: center; text-transform: lowercase;">
+        more in the basement · <a href="https://github.com/ahujatries">github.com/ahujatries</a>
+      </div>
     </main>
 
     <div id="footer-mount"></div>

--- a/notes.html
+++ b/notes.html
@@ -3,18 +3,17 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="raghav ahuja — notes. Writing on design engineering, infrastructure, and craft.">
-  <meta name="theme-color" content="#15110D">
-  <title>notes · raghav ahuja</title>
-      <link rel="preload" href="fonts/InstrumentSerif-Regular.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="fonts/InstrumentSerif-Italic.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="fonts/JetBrainsMono.woff2" as="font" type="font/woff2" crossorigin>
+  <meta name="description" content="raghav ahuja — writing. Essays, notes, asides.">
+  <meta name="theme-color" content="#0c0c0e">
+  <title>writing · raghav ahuja</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="site.css">
   <link rel="canonical" href="https://raghavahuja.com/notes">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://raghavahuja.com/notes">
-  <meta property="og:title" content="notes · raghav ahuja">
-  <meta property="og:description" content="Short, specific things I've learned while shipping. No thought leadership.">
+  <meta property="og:title" content="writing · raghav ahuja">
+  <meta property="og:description" content="Essays, notes, asides — longer thoughts, in chronological reverse.">
   <meta property="og:image" content="https://raghavahuja.com/og.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
@@ -22,10 +21,10 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@ahujatries">
   <meta name="twitter:creator" content="@ahujatries">
-  <meta name="twitter:title" content="notes · raghav ahuja">
-  <meta name="twitter:description" content="Short, specific things I've learned while shipping. No thought leadership.">
+  <meta name="twitter:title" content="writing · raghav ahuja">
+  <meta name="twitter:description" content="Essays, notes, asides.">
   <meta name="twitter:image" content="https://raghavahuja.com/og.png">
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%22.9em%22 font-size=%2290%22 fill=%22%230070F3%22%3E_%3C/text%3E%3C/svg%3E">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%22.92em%22 font-size=%2290%22 fill=%22%235b8cff%22%3E_%3C/text%3E%3C/svg%3E">
 </head>
 <body data-page="notes">
   <script>try { var s = localStorage.getItem('theme'); if (s) document.documentElement.setAttribute('data-theme', s); } catch (e) {}</script>
@@ -36,27 +35,57 @@
     <div id="nav-mount"></div>
 
     <main id="main">
+      <div class="folio-strip">folio 05 — writing · longer thoughts, in chronological reverse</div>
 
-    <section style="padding: 72px 0 40px;">
-      <div class="kicker">folio 04 — the writing</div>
-      <h1 style="margin-top: 28px; margin-bottom: 32px; max-width: 18ch;">
-        Notes, <span class="em-serif">not posts.</span>
-      </h1>
-      <p class="sub" style="font-family: var(--font-display); font-size: 20px; line-height: 1.55; color: var(--fg-muted); max-width: 60ch; margin-bottom: 8px;">
-        Short, specific things I've learned while shipping. No thought leadership. No "five things I wish I knew." <a href="#">rss →</a>
-      </p>
-    </section>
+      <section style="padding: 48px 0 40px; border-bottom: 1px solid var(--soft-rule); max-width: 900px;">
+        <h1 style="font-family: var(--font-display); font-size: var(--fs-h1); line-height: 1; color: var(--ink); margin: 0;">
+          Writing.<br>
+          <span class="italic" style="color: var(--dim);">essays, notes, asides.</span>
+        </h1>
+      </section>
 
-    <section class="section">
-      <div class="notes-list">
-        <div class="note-row note-row--wip"><span class="date">soon</span><span class="title">A $19/month infrastructure ceiling <span class="wip-tag">draft</span></span><span class="tag">infra</span></div>
-        <div class="note-row note-row--wip"><span class="date">soon</span><span class="title">Why I wrote a screenplay paginator from scratch <span class="wip-tag">draft</span></span><span class="tag">arqo</span></div>
-        <div class="note-row note-row--wip"><span class="date">soon</span><span class="title">Lossless round-trip is a unit test, not a feature <span class="wip-tag">draft</span></span><span class="tag">arqo</span></div>
-        <div class="note-row note-row--wip"><span class="date">soon</span><span class="title">Mobile-first doesn't mean "responsive-later" <span class="wip-tag">draft</span></span><span class="tag">craft</span></div>
-        <div class="note-row note-row--wip"><span class="date">soon</span><span class="title">Notes on becoming a design engineer <span class="wip-tag">draft</span></span><span class="tag">career</span></div>
+      <div style="margin-top: 16px;">
+        <a href="#" class="note-row">
+          <span class="date">26·04·22</span>
+          <span class="title">Why I shipped a screenwriting app in nine days.</span>
+          <span class="kind">· essay</span>
+        </a>
+        <a href="#" class="note-row">
+          <span class="date">26·04·14</span>
+          <span class="title">The hiring manager doesn't want a portfolio.</span>
+          <span class="kind">· essay</span>
+        </a>
+        <a href="#" class="note-row">
+          <span class="date">26·03·30</span>
+          <span class="title">On reading 777 screenplays in two weeks.</span>
+          <span class="kind">· note</span>
+        </a>
+        <a href="#" class="note-row">
+          <span class="date">26·03·12</span>
+          <span class="title">A working theory of design engineering.</span>
+          <span class="kind">· essay</span>
+        </a>
+        <a href="#" class="note-row">
+          <span class="date">26·02·28</span>
+          <span class="title">Tools I gave up on this quarter.</span>
+          <span class="kind">· list</span>
+        </a>
+        <a href="#" class="note-row">
+          <span class="date">26·02·09</span>
+          <span class="title">The brief is the design.</span>
+          <span class="kind">· note</span>
+        </a>
+        <a href="#" class="note-row">
+          <span class="date">26·01·22</span>
+          <span class="title">Notes from migrating 1,400 design tokens.</span>
+          <span class="kind">· essay</span>
+        </a>
+        <a href="#" class="note-row">
+          <span class="date">25·12·14</span>
+          <span class="title">Brooklyn, in winter, while debugging.</span>
+          <span class="kind">· aside</span>
+        </a>
       </div>
-    </section>
-
     </main>
 
     <div id="footer-mount"></div>

--- a/site.css
+++ b/site.css
@@ -1,1284 +1,759 @@
-/* site.css — Direction A · Dark (burnt ink + terracotta · candlelit editorial) */
-@import url('./tokens.css?v=directionA');
+/* site.css — folio · vol. iv · no. 4 (cobalt × bone × ink) */
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;1,9..144,400&family=Geist:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap');
+@import url('./tokens.css?v=folio4');
 
 * { box-sizing: border-box; }
-body { margin: 0; min-height: 100vh; }
+body { margin: 0; min-height: 100vh; background: var(--paper); color: var(--ink); }
 
 /* skip-link */
 .skip-link {
   position: absolute; top: -100px; left: 0;
   background: var(--accent); color: var(--accent-ink) !important;
-  font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.04em; font-weight: 700;
+  font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.04em;
   padding: 10px 16px; z-index: 999; text-decoration: none;
   transition: top 120ms var(--ease-out);
 }
 .skip-link:focus { top: 0; outline: 2px solid var(--accent-ink); outline-offset: -2px; }
 
-/* view-source handle — tooltip on hover */
-.vs-handle {
-  position: absolute; top: 8px; right: 8px;
-  background: transparent; border: 1px solid var(--line);
-  width: 24px; height: 24px; display: grid; place-items: center;
-  font-family: var(--font-mono); font-size: 11px; color: var(--fg-muted);
-  cursor: pointer;
-}
-.vs-handle:hover { color: var(--accent); border-color: var(--accent); }
-.vs-handle::after {
-  content: "see the source";
-  position: absolute; right: calc(100% + 8px); top: 50%; transform: translateY(-50%);
-  background: var(--bg-raise); border: 1px solid var(--line);
-  font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.04em;
-  color: var(--fg-muted); padding: 3px 8px;
-  white-space: nowrap; opacity: 0; pointer-events: none;
-  transition: opacity 120ms var(--ease-out);
-}
-.vs-handle:hover::after { opacity: 1; }
-
-/* view-source first-time hint */
-.vs-hint {
-  position: absolute; top: 10px; right: 44px;
-  background: var(--accent); color: var(--accent-ink) !important;
-  font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.04em;
-  padding: 5px 10px; border-radius: var(--r-2);
-  cursor: pointer; z-index: 5;
-  opacity: 0; transform: translateX(6px);
-  animation: vs-hint-in 200ms var(--ease-out) 900ms forwards;
-  box-shadow: 0 4px 16px rgba(232,106,78,0.3);
-}
-.vs-hint code { background: rgba(26,18,8,0.2); border: 0; color: var(--accent-ink); padding: 0 4px; }
-.vs-hint::after {
-  content: ""; position: absolute; top: 50%; right: -4px;
-  transform: translateY(-50%) rotate(45deg);
-  width: 6px; height: 6px; background: var(--accent);
-}
-.vs-hint--gone { opacity: 0; transform: translateX(-4px); transition: all 300ms var(--ease-out); }
-@keyframes vs-hint-in { to { opacity: 1; transform: translateX(0); } }
-@media (prefers-reduced-motion: reduce) { .vs-hint { animation: none; opacity: 1; transform: none; } }
-
-.wrap { max-width: var(--grid-max); margin: 0 auto; padding: 0 32px; }
+.wrap { max-width: var(--grid-max); margin: 0 auto; padding: 0 var(--grid-pad); }
 .mono { font-family: var(--font-mono); }
-.kicker {
-  font-family: var(--font-mono); font-size: 11px;
-  letter-spacing: 0.12em; text-transform: uppercase;
-  color: var(--fg-dim);
-}
-.label-chrome {
-  font-family: var(--font-mono); font-size: 11px;
-  letter-spacing: 0.04em; text-transform: lowercase;
-  color: var(--fg-muted);
-}
-.hairline { border-top: 1px solid var(--line); }
+.italic { font-style: italic; }
+.serif { font-family: var(--font-display); }
 
-/* italic serif accent — used for any "and", "or", emphasis */
-.em-serif { font-style: italic; color: var(--accent); }
+.label-chrome {
+  font-family: var(--font-mono); font-size: var(--fs-meta);
+  letter-spacing: var(--tr-wide); text-transform: lowercase;
+  color: var(--dim);
+}
+.hairline { border-top: 1px solid var(--rule); }
+.softline { border-top: 1px solid var(--soft-rule); }
+
+.em-serif, .em-accent { font-style: italic; color: var(--accent); }
 
 /* ====================================================
-   NAV — editorial
+   MASTHEAD — vol/no editorial strip (3 columns)
+   ==================================================== */
+.masthead {
+  display: grid; grid-template-columns: 1fr auto 1fr;
+  align-items: center; gap: 16px;
+  padding: 14px var(--grid-pad);
+  border-bottom: 1px solid var(--soft-rule);
+  font-family: var(--font-mono); font-size: var(--fs-meta);
+  letter-spacing: var(--tr-wide); text-transform: lowercase;
+  color: var(--dim);
+}
+.masthead .mh-vol { }
+.masthead .mh-mid { text-align: center; }
+.masthead .mh-clocks { text-align: right; display: flex; gap: 18px; justify-content: flex-end; }
+.masthead .mh-clocks b { color: var(--ink); font-weight: 400; }
+
+/* legacy alias used by site.js */
+.status-bar { display: none; }
+
+/* ====================================================
+   NAV — brand mark + links + ⌘K
    ==================================================== */
 .nav {
-  display: flex; justify-content: space-between; align-items: baseline;
-  padding: 20px 0; border-bottom: 1px solid var(--line);
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: 32px; padding: 24px var(--grid-pad) 18px;
   position: relative;
 }
-.nav-left { display: flex; gap: 28px; align-items: baseline; font-family: var(--font-mono); font-size: 13px; }
-.nav-links { display: flex; gap: 28px; align-items: baseline; }
-.nav-left a { color: var(--fg-muted); text-decoration: none; }
-.nav-left a:hover { color: var(--accent); }
-.nav-left a.active {
-  color: var(--fg);
-  border-bottom: 1px solid var(--accent);
-  padding-bottom: 2px;
-}
+.nav-left { display: flex; align-items: baseline; gap: 28px; }
 .brand {
-  font-family: var(--font-mono); font-weight: 700;
-  color: var(--fg) !important;
-  font-size: 14px; letter-spacing: -0.01em;
+  font-family: var(--font-mono);
+  font-size: 22px; font-weight: 500;
+  letter-spacing: -0.02em;
+  color: var(--accent);
+  text-decoration: none;
+  line-height: 1;
+  display: inline-flex; align-items: baseline;
 }
-.brand .caret { color: var(--accent); }
-@keyframes blink { 0%,50% { opacity: 1; } 51%,100% { opacity: 0; } }
-.nav-right { display: flex; gap: 8px; align-items: center; }
-.kbd {
-  font-family: var(--font-mono); font-size: 11px;
-  padding: 2px 6px; border: 1px solid var(--line-strong);
-  border-bottom-width: 2px; border-radius: var(--r-1);
-  background: var(--bg-raise); color: var(--fg);
+.brand .caret {
+  display: inline-block;
+  width: 0.55em; height: 0.95em;
+  background: var(--accent);
+  margin-left: 2px;
+  transform: translateY(0.06em);
+  animation: ra-blink 1.06s steps(1) infinite;
+}
+@keyframes ra-blink { 50% { opacity: 0; } }
+@media (prefers-reduced-motion: reduce) { .brand .caret { animation: none; } }
+
+.nav-links { display: flex; align-items: baseline; gap: 22px; flex-wrap: wrap; }
+.nav-links a {
+  font-family: var(--font-body);
+  font-size: var(--fs-small);
+  color: var(--dim);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+  transition: color var(--dur-fast) var(--ease-out);
+}
+.nav-links a:hover { color: var(--ink); }
+.nav-links a.active {
+  color: var(--ink);
+  border-bottom-color: var(--accent);
 }
 
-/* hamburger toggle */
+.nav-right { display: flex; align-items: center; gap: 10px; }
+.nav-divider { width: 1px; height: 14px; background: var(--rule); margin: 0 4px; }
+.nav-btn {
+  font-family: var(--font-mono); font-size: var(--fs-meta);
+  letter-spacing: var(--tr-wide); text-transform: lowercase;
+  background: transparent; color: var(--dim);
+  border: 1px solid var(--rule);
+  padding: 6px 10px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+  transition: color var(--dur-fast) var(--ease-out), border-color var(--dur-fast) var(--ease-out);
+}
+.nav-btn:hover { color: var(--ink); border-color: var(--strong-rule); }
+.nav-btn--solid {
+  background: var(--sub); color: var(--ink);
+}
+.nav-btn .kbd {
+  font-family: inherit; font-size: 9px;
+  padding: 1px 5px; border: 1px solid var(--rule);
+  border-radius: 3px; background: transparent;
+}
+
+/* legacy alias used by site.js */
+.nav-search { display: inline-flex; align-items: center; gap: 8px; background: transparent; border: 1px solid var(--rule); padding: 6px 10px; color: var(--dim); cursor: pointer; font: inherit; font-family: var(--font-mono); font-size: var(--fs-meta); letter-spacing: var(--tr-wide); text-transform: lowercase; }
+.nav-search:hover { color: var(--ink); }
+.kbd { font-family: var(--font-mono); font-size: 9px; padding: 1px 5px; border: 1px solid var(--rule); border-radius: 3px; background: transparent; color: inherit; }
+
+/* hamburger */
 .nav-toggle {
   display: none;
-  background: transparent; border: 1px solid var(--line);
-  width: 36px; height: 36px;
-  padding: 0; cursor: pointer;
+  background: transparent; border: 1px solid var(--rule);
+  width: 36px; height: 36px; padding: 0; cursor: pointer;
   flex-direction: column; justify-content: center; align-items: center; gap: 5px;
-  transition: border-color 120ms var(--ease-out);
 }
-.nav-toggle:hover { border-color: var(--accent); }
-.nav-toggle-bar {
-  display: block; width: 16px; height: 1.5px;
-  background: var(--fg-muted);
-  transition: transform 180ms var(--ease-out), opacity 120ms var(--ease-out), background 120ms var(--ease-out);
-}
-.nav.open .nav-toggle { border-color: var(--accent); }
-.nav.open .nav-toggle-bar { background: var(--accent); }
+.nav-toggle-bar { display: block; width: 16px; height: 1.5px; background: var(--dim); transition: transform 180ms var(--ease-out), opacity 120ms var(--ease-out); }
 .nav.open .nav-toggle-bar:nth-child(1) { transform: translateY(6.5px) rotate(45deg); }
 .nav.open .nav-toggle-bar:nth-child(2) { opacity: 0; }
 .nav.open .nav-toggle-bar:nth-child(3) { transform: translateY(-6.5px) rotate(-45deg); }
 
-@media (max-width: 719px) {
+@media (max-width: 800px) {
+  .nav { flex-wrap: wrap; gap: 16px; }
   .nav-toggle { display: flex; }
-  .nav-links { display: none; }
-  .nav-right .nav-search { display: none; }
+  .nav-links { display: none; width: 100%; flex-direction: column; gap: 0; }
   .nav.open .nav-links {
-    display: flex; flex-direction: column; gap: 0;
-    position: absolute; top: 100%; left: 0; right: 0;
-    background: var(--bg-raise);
-    border-bottom: 1px solid var(--line-strong);
-    padding: 8px 32px 16px; z-index: 50; font-size: 15px;
-    box-shadow: var(--shadow-pop);
+    display: flex; padding: 8px 0;
+    border-top: 1px solid var(--soft-rule);
   }
-  .nav.open .nav-links a { padding: 12px 0; border-bottom: 1px solid var(--line); }
-  .nav.open .nav-links a:last-child { border-bottom: 0; }
-  .nav.open .nav-links a.active { border-bottom: 1px solid var(--line); color: var(--accent); }
+  .nav.open .nav-links a { padding: 12px 0; border-bottom: 1px solid var(--soft-rule); }
+  .nav-right .nav-btn--solid { display: none; }
 }
-
-.nav-search {
-  display: inline-flex; align-items: center; gap: 8px;
-  background: transparent; border: 0; padding: 4px 6px;
-  color: var(--fg-muted); cursor: pointer; font: inherit;
-}
-.nav-search:hover { color: var(--accent); }
-.nav-search:hover .kbd { border-color: var(--accent); color: var(--accent); }
 
 /* ====================================================
-   STATUS BAR — vol/no editorial strip
+   FOLIO STRIP / EYEBROW
    ==================================================== */
-.status-bar {
-  display: flex; justify-content: space-between; align-items: center;
-  padding: 8px 32px; border-bottom: 1px solid var(--line);
-  font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.04em;
-  color: var(--fg-muted); background: transparent;
+.folio-strip {
+  font-family: var(--font-mono); font-size: var(--fs-meta);
+  color: var(--mute); text-transform: lowercase;
+  padding: 40px 0 14px;
+  border-bottom: 1px solid var(--soft-rule);
+  display: flex; justify-content: space-between; gap: 16px; flex-wrap: wrap;
 }
-.sb-left em, .sb-left .em-accent { color: var(--accent); font-style: normal; }
-.sb-dot {
-  display: inline-block; width: 6px; height: 6px; border-radius: 50%;
-  background: var(--live); box-shadow: 0 0 8px var(--live);
-  margin-right: 6px; vertical-align: 1px;
-}
-.sb-clocks { display: flex; gap: 20px; }
-.sb-clocks b { color: var(--fg); font-weight: 400; }
 
 /* ====================================================
-   HERO — editorial, serif-forward
+   HOME — hero
    ==================================================== */
-
-/* entrance stagger — eyebrow → h1 → sub → ctas fade + rise into place */
-.hero .eyebrow,
-.hero h1,
-.hero .sub,
-.hero-ctas {
-  opacity: 0;
-  transform: translateY(8px);
-  animation: hero-in 420ms var(--ease-out) forwards;
+.hero-grid {
+  display: grid; grid-template-columns: 1.4fr 1fr;
+  gap: 64px; padding: 56px 0 48px;
+  border-bottom: 1px solid var(--soft-rule);
 }
-.hero .eyebrow   { animation-delay:   0ms; }
-.hero h1         { animation-delay:  80ms; }
-.hero .sub       { animation-delay: 180ms; }
-.hero-ctas       { animation-delay: 280ms; }
-@keyframes hero-in {
-  to { opacity: 1; transform: translateY(0); }
-}
-@media (prefers-reduced-motion: reduce) {
-  .hero .eyebrow, .hero h1, .hero .sub, .hero-ctas {
-    animation: none; opacity: 1; transform: none;
-  }
-}
-
-.hero { padding: 72px 0 56px; position: relative; }
-.hero-marker {
-  display: flex; justify-content: space-between;
-  font-family: var(--font-mono); font-size: 11px; color: var(--fg-dim);
-  letter-spacing: 0.08em; text-transform: uppercase;
-  border-top: 1px dashed var(--line); padding-top: 12px;
-}
-.hero .eyebrow {
-  font-family: var(--font-mono); font-size: 11px; color: var(--fg-dim);
-  letter-spacing: 0.12em; text-transform: uppercase;
-  margin: 28px 0 28px 0;
-}
-.hero h1 {
+.hero-grid h1 {
   font-family: var(--font-display);
-  font-size: 96px; line-height: 1.02;
-  letter-spacing: -0.025em; font-weight: 400;
-  color: var(--fg); max-width: 14ch;
-  margin: 0;
+  font-size: var(--fs-hero); line-height: 0.95;
+  letter-spacing: -0.035em; font-weight: 400;
+  color: var(--ink); margin: 0;
+  font-feature-settings: 'ss01', 'ss02';
 }
-.hero h1 .em-serif { font-style: italic; color: var(--accent); }
-.hero .sub {
-  font-family: var(--font-display);
-  font-size: 21px; line-height: 1.55; color: var(--fg-muted);
-  max-width: 52ch; margin-top: 40px; font-weight: 400;
+.hero-grid h1 .em-accent { font-style: italic; color: var(--accent); }
+.hero-grid .lead {
+  font-family: var(--font-body); font-size: var(--fs-lead);
+  line-height: var(--lh-lead); letter-spacing: -0.005em;
+  color: var(--dim); max-width: 540px; margin: 36px 0 0;
 }
-.hero-ctas { display: flex; gap: 14px; margin-top: 40px; align-items: center; flex-wrap: wrap; }
+.hero-ctas { display: flex; gap: 14px; margin-top: 32px; flex-wrap: wrap; align-items: center; }
+
+/* primary / ghost buttons */
 .cta {
-  font-family: var(--font-mono); font-size: 13px;
-  padding: 12px 20px; border: 1px solid var(--fg);
-  color: var(--fg); text-decoration: none;
-  letter-spacing: 0.02em; transition: all 120ms var(--ease-out);
+  font-family: var(--font-body); font-size: var(--fs-small);
+  padding: 12px 18px; border: 1px solid var(--rule);
+  background: transparent; color: var(--ink);
+  text-decoration: none; cursor: pointer;
+  transition: border-color var(--dur-fast) var(--ease-out), color var(--dur-fast) var(--ease-out);
 }
-.cta:hover { border-color: var(--accent); color: var(--accent); }
+.cta:hover { border-color: var(--strong-rule); }
 .cta-primary {
   background: var(--accent); border-color: var(--accent);
-  color: var(--accent-ink); font-weight: 700;
+  color: var(--accent-ink); font-weight: 500;
 }
-.cta-primary:hover {
-  background: var(--accent-hover); border-color: var(--accent-hover);
-  color: var(--accent-ink);
+.cta-primary:hover { background: var(--accent-hover); border-color: var(--accent-hover); color: var(--accent-ink); }
+.cta-hint { font-family: var(--font-body); font-size: var(--fs-small); color: var(--mute); align-self: center; margin-left: 4px; }
+
+/* hero side card — currently shipping */
+.hero-card {
+  border: 1px solid var(--rule); padding: 28px;
+  background: var(--bone); align-self: start;
 }
-.cta-hint { font-family: var(--font-mono); font-size: 12px; color: var(--fg-dim); margin-left: 8px; }
+.hero-card .hc-eyebrow {
+  font-family: var(--font-mono); font-size: var(--fs-meta);
+  color: var(--mute); text-transform: lowercase;
+}
+.hero-card .hc-title {
+  font-family: var(--font-display); font-size: var(--fs-h3);
+  font-style: italic; color: var(--ink);
+  margin-top: 8px; line-height: 1.15;
+}
+.hero-card .hc-rule { height: 1px; background: var(--rule); margin: 20px 0; }
+.hero-card .hc-grid {
+  display: grid; grid-template-columns: 64px 1fr;
+  row-gap: 10px; column-gap: 16px;
+  font-family: var(--font-body); font-size: var(--fs-small);
+  color: var(--dim);
+}
+.hero-card .hc-k {
+  font-family: var(--font-mono); font-size: var(--fs-meta);
+  color: var(--mute); text-transform: lowercase;
+}
+.hero-card .hc-v { color: var(--ink); }
+.hero-card .hc-v em { color: var(--dim); font-style: italic; }
 
 /* ====================================================
-   SHIP LOG (live activity) + NOW — editorial tables
+   CURATED HIGHLIGHTS — replaces ship-log
    ==================================================== */
-.ship-log, .now-block {
-  padding: 32px 0; border-top: 1px solid var(--line);
-  position: relative;
-}
-.section-eyebrow {
+.highlights { padding: 48px 0; border-bottom: 1px solid var(--soft-rule); }
+.highlights-head {
   display: flex; justify-content: space-between; align-items: baseline;
-  font-family: var(--font-mono); font-size: 11px;
-  color: var(--fg-muted); letter-spacing: 0.08em; text-transform: uppercase;
-  margin-bottom: 20px;
 }
-.section-eyebrow .meta { color: var(--fg-dim); text-transform: none; letter-spacing: 0.04em; }
-
-.live-row {
-  display: grid; grid-template-columns: 92px 80px 1fr 70px; gap: 16px;
-  padding: 10px 0; border-bottom: 1px dashed var(--line-soft);
-  font-family: var(--font-mono); font-size: 12.5px; align-items: baseline;
+.highlights-head .label { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--mute); text-transform: lowercase; }
+.highlights-head a { font-family: var(--font-body); font-size: var(--fs-small); color: var(--dim); text-decoration: none; }
+.highlights-head a:hover { color: var(--ink); }
+.highlights-grid {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  gap: 16px; margin-top: 18px;
 }
-.live-row:last-child { border-bottom: 0; }
-.live-row:hover { background: rgba(232,106,78,0.04); }
-.live-row .date { color: var(--fg-dim); }
-.live-row .repo { color: var(--accent); font-weight: 600; }
-.live-row .commit-msg { color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.live-row .when { color: var(--fg-dim); text-align: right; font-size: 11px; }
-
-.now-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 32px; }
-.now-row {
-  display: flex; gap: 14px;
-  padding-bottom: 12px; border-bottom: 1px dashed var(--line-soft);
+.hl-card {
+  border: 1px solid var(--rule); background: var(--bone);
+  padding: 18px; min-height: 168px;
+  display: flex; flex-direction: column;
+  text-decoration: none; color: var(--ink);
+  transition: border-color var(--dur-fast) var(--ease-out);
 }
-.now-k {
-  font-family: var(--font-mono); font-size: 11px; color: var(--fg-dim);
-  min-width: 80px; text-transform: lowercase; letter-spacing: 0.04em;
-  padding-top: 2px;
+.hl-card:hover { border-color: var(--strong-rule); }
+.hl-card .hl-row {
+  display: flex; justify-content: space-between;
+  font-family: var(--font-mono); font-size: var(--fs-meta);
+  color: var(--mute); text-transform: lowercase;
 }
-.now-v {
-  font-family: var(--font-display); font-size: 17px;
-  color: var(--fg); line-height: 1.4;
-}
-.now-v em { color: var(--fg-muted); }
-
-@media (max-width: 720px) {
-  .now-grid { grid-template-columns: 1fr; gap: 0; }
-  .live-row { grid-template-columns: 80px 60px 1fr 50px; gap: 10px; font-size: 11.5px; }
-}
-
-/* ====================================================
-   WORK INDEX — editorial list rows
-   ==================================================== */
-.section { padding: 40px 0; border-top: 1px solid var(--line); }
-.section-head {
-  display: flex; justify-content: space-between; align-items: baseline;
-  margin-bottom: 28px;
-}
-.section-head h2 {
+.hl-card .hl-tag { color: var(--accent); }
+.hl-card .hl-title {
   font-family: var(--font-display);
-  font-size: 38px; line-height: 1.1;
-  letter-spacing: -0.02em; font-weight: 400;
-  color: var(--fg);
+  font-size: 19px; line-height: 1.2;
+  color: var(--ink); margin-top: auto;
 }
-.section-head a { font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.04em; color: var(--accent); }
+.hl-card .hl-kind {
+  font-family: var(--font-mono); font-size: var(--fs-meta);
+  color: var(--mute); text-transform: lowercase; margin-top: 10px;
+}
 
-.work-row {
-  display: grid; grid-template-columns: 40px 1fr 220px 60px; gap: 24px;
-  padding: 20px 0; border-top: 1px solid var(--line-soft);
-  text-decoration: none; color: var(--fg); align-items: baseline;
-  position: relative;
-  transition: background 120ms var(--ease-out);
+@media (max-width: 980px) {
+  .hero-grid { grid-template-columns: 1fr; gap: 32px; }
+  .hero-grid h1 { font-size: 64px; line-height: 1; }
+  .highlights-grid { grid-template-columns: repeat(2, 1fr); }
 }
-.work-row:hover { background: rgba(232,106,78,0.04); }
-.work-row .n { font-family: var(--font-mono); font-size: 12px; color: var(--fg-dim); padding-top: 8px; }
+@media (max-width: 560px) {
+  .highlights-grid { grid-template-columns: 1fr; }
+  .hero-grid h1 { font-size: 48px; }
+}
+
+/* ====================================================
+   SECTION + SELECTED WORK
+   ==================================================== */
+.section { padding: 56px 0 8px; }
+.section-head {
+  display: flex; justify-content: space-between; align-items: baseline; gap: 16px;
+}
+.section-head h2 { font-family: var(--font-display); font-size: var(--fs-h2); margin: 0; color: var(--ink); }
+.section-head a { font-family: var(--font-body); font-size: var(--fs-small); color: var(--dim); text-decoration: none; }
+.section-head a:hover { color: var(--ink); }
+
+.work-list { margin-top: 28px; }
+.work-row {
+  display: grid; grid-template-columns: 40px 1fr 1fr 80px;
+  gap: 28px; padding: 28px 0;
+  border-top: 1px solid var(--soft-rule);
+  text-decoration: none; color: var(--ink);
+  align-items: baseline;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+.work-row:hover { background: var(--accent-soft); }
+.work-row .n { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--mute); }
 .work-row h3 {
   font-family: var(--font-display);
-  font-size: 28px; line-height: 1.1; letter-spacing: -0.01em; font-weight: 400;
-  margin-bottom: 4px;
-}
-.work-row .sub {
-  font-family: var(--font-display); font-size: 15px;
-  color: var(--fg-muted); line-height: 1.5; font-style: italic;
-  margin: 0;
+  font-size: 32px; line-height: 1.05;
+  letter-spacing: var(--tr-snug); font-weight: 400;
+  color: var(--ink); margin: 0;
 }
 .work-row .meta {
-  font-family: var(--font-mono); font-size: 11px;
-  color: var(--fg-dim); text-transform: lowercase; letter-spacing: 0.04em;
-  line-height: 1.7;
+  font-family: var(--font-mono); font-size: var(--fs-meta);
+  color: var(--mute); text-transform: lowercase; margin-top: 6px;
+}
+.work-row .blurb {
+  font-family: var(--font-body); font-size: var(--fs-body);
+  color: var(--dim); max-width: 480px; margin: 0;
 }
 .work-row .year {
-  font-family: var(--font-mono); font-size: 12px;
-  color: var(--accent); text-align: right; padding-top: 8px;
-}
-@media (max-width: 720px) {
-  .work-row { grid-template-columns: 32px 1fr; gap: 12px; }
-  .work-row .meta, .work-row .year { grid-column: 2; }
-  .work-row .year { text-align: left; }
+  font-family: var(--font-mono); font-size: var(--fs-meta);
+  color: var(--mute); text-align: right;
 }
 
-/* ====================================================
-   LAB + NOTES lists (editorial)
-   ==================================================== */
-.lab-list, .notes-list { padding-top: 12px; }
-.lab-row, .note-row {
-  display: grid; grid-template-columns: 100px 1fr 140px; gap: 16px;
-  padding: 16px 0; border-bottom: 1px dashed var(--line-soft);
-  align-items: baseline;
+.locked-chip {
+  font-family: var(--font-mono); font-size: var(--fs-meta);
+  color: var(--warn); padding: 2px 8px;
+  border: 1px solid var(--warn); text-transform: lowercase;
+  display: inline-block; margin-left: 8px; vertical-align: middle;
 }
-.lab-row .date, .note-row .date { font-family: var(--font-mono); font-size: 11px; color: var(--fg-dim); letter-spacing: 0.04em; }
-.lab-row .title, .note-row .title {
-  font-family: var(--font-display); font-size: 20px; color: var(--fg);
-}
-.lab-row .title em, .note-row .title em { color: var(--fg-muted); font-style: italic; }
-.lab-row .tag, .note-row .tag {
-  font-family: var(--font-mono); font-size: 11px; color: var(--accent);
-  text-align: right; letter-spacing: 0.04em; text-transform: lowercase;
-}
-.lab-row--wip, .note-row--wip { cursor: default; }
-.lab-row--wip:hover, .note-row--wip:hover { background: transparent; }
-
-.wip-tag {
-  display: inline-block; margin-left: 8px;
-  font-family: var(--font-mono); font-size: 10px;
-  color: var(--accent); border: 1px solid var(--accent-dim);
-  padding: 1px 6px; border-radius: var(--r-2);
-  letter-spacing: 0.04em; text-transform: lowercase;
-  vertical-align: middle;
+.open-chip {
+  font-family: var(--font-mono); font-size: var(--fs-meta);
+  color: var(--pos); padding: 2px 8px;
+  border: 1px solid var(--pos); text-transform: lowercase;
+  display: inline-block; margin-left: 8px; vertical-align: middle;
 }
 
-/* ====================================================
-   CASE STUDY — editorial reading spread (Direction A)
-   ==================================================== */
-
-/* reading-progress sliver — thin terracotta bar at top */
-.case-progress {
-  position: fixed; top: 0; left: 0; right: 0; height: 2px;
-  background: transparent; z-index: 200; pointer-events: none;
-}
-.case-progress .bar {
-  height: 100%; width: 0%;
-  background: var(--accent);
-  transition: width 80ms linear;
-}
-@media (prefers-reduced-motion: reduce) { .case-progress .bar { transition: none; } }
-
-/* layout — centered column + optional vertical spine + optional TOC rail */
-.case-layout {
-  display: grid;
-  grid-template-columns: 56px 1fr 56px;
-  gap: 32px;
-  max-width: var(--grid-max);
-  margin: 0 auto;
-}
-@media (min-width: 1100px) {
-  .case-layout.has-toc {
-    grid-template-columns: 56px minmax(0, 1fr) 200px;
-  }
-}
-
-/* sticky table of contents rail — only on desktop */
-.case-toc {
-  display: none;
-}
-@media (min-width: 1100px) {
-  .case-layout.has-toc .case-toc {
-    display: block;
-    position: sticky;
-    top: 32px;
-    align-self: start;
-    padding-top: 80px;
-    max-height: calc(100vh - 64px);
-    overflow-y: auto;
-  }
-}
-.case-toc .label {
-  font-family: var(--font-mono); font-size: 10px;
-  color: var(--fg-dim); letter-spacing: 0.12em;
-  text-transform: uppercase;
-  margin-bottom: 14px;
-}
-.case-toc ol {
-  list-style: none; padding: 0; margin: 0;
-  counter-reset: toc;
-}
-.case-toc li {
-  counter-increment: toc;
-  padding: 4px 0 4px 28px;
-  position: relative;
-  font-family: var(--font-display); font-size: 14px; line-height: 1.4;
-  border-left: 1px solid var(--line);
-}
-.case-toc li::before {
-  content: counter(toc, decimal-leading-zero);
-  position: absolute; left: 8px; top: 6px;
-  font-family: var(--font-mono); font-size: 9px;
-  color: var(--fg-dim); letter-spacing: 0.04em;
-}
-.case-toc a {
-  color: var(--fg-muted); text-decoration: none;
-  display: block; padding: 2px 0;
-  transition: color 120ms var(--ease-out);
-}
-.case-toc a:hover { color: var(--accent); }
-.case-toc li.active {
-  border-left-color: var(--accent);
-}
-.case-toc li.active a {
-  color: var(--fg);
-}
-.case-toc li.active::before { color: var(--accent); }
-.case-spine {
-  font-family: var(--font-mono); font-size: 11px; color: var(--fg-dim);
-  letter-spacing: 0.12em; text-transform: uppercase;
-  writing-mode: vertical-rl; transform: rotate(180deg);
-  padding-top: 80px;
-  white-space: nowrap;
-}
-.case-content { min-width: 0; }
 @media (max-width: 860px) {
-  .case-layout { grid-template-columns: 1fr; gap: 0; }
-  .case-spine { display: none; }
-}
-
-/* head block */
-.case-head { padding: 56px 0 32px; border-bottom: 1px solid var(--line); }
-.case-head .kicker { margin-bottom: 12px; }
-.case-head h1 {
-  font-family: var(--font-display);
-  font-size: 84px; line-height: 1.02;
-  letter-spacing: -0.02em; font-weight: 400;
-  margin: 8px 0 0;
-}
-.case-head .subtitle {
-  font-family: var(--font-display); font-style: italic;
-  color: var(--fg-muted); font-size: 24px; line-height: 1.4;
-  max-width: 56ch; margin-top: 16px;
-}
-.case-meta {
-  display: grid; grid-template-columns: repeat(2, 1fr); gap: 20px 32px;
-  padding: 24px 0; border-top: 1px solid var(--line);
-  border-bottom: 1px solid var(--line); margin-top: 32px;
-}
-.case-meta .k {
-  color: var(--fg-dim); letter-spacing: 0.04em; text-transform: lowercase;
-  font-family: var(--font-mono); font-size: 11px;
-  margin-bottom: 4px;
-}
-.case-meta > div > div:last-child {
-  font-family: var(--font-mono); font-size: 13px; color: var(--fg);
-  line-height: 1.55;
-}
-@media (min-width: 720px) {
-  .case-meta { grid-template-columns: repeat(4, 1fr); }
-}
-
-/* stack receipts — grep-able deps with versions */
-.case-stack {
-  padding: 24px 0;
-  border-bottom: 1px solid var(--line);
-}
-.case-stack .label {
-  font-family: var(--font-mono); font-size: 11px;
-  color: var(--fg-dim); letter-spacing: 0.12em;
-  text-transform: uppercase; margin-bottom: 14px;
-}
-.case-stack-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 4px 24px;
-  font-family: var(--font-mono); font-size: 12.5px;
-}
-.case-stack-row {
-  display: grid; grid-template-columns: 1fr auto;
-  padding: 6px 0;
-  border-bottom: 1px dashed var(--line-soft);
-  color: var(--fg);
-}
-.case-stack-row:last-child { border-bottom: 0; }
-.case-stack-row .dep { color: var(--fg); }
-.case-stack-row .ver { color: var(--accent); }
-
-/* body — editorial reader */
-.case-body { padding: 40px 0; max-width: 68ch; }
-.case-body > *:first-child { margin-top: 0; }
-.case-body h2 {
-  font-family: var(--font-display);
-  font-size: 38px; line-height: 1.12; font-weight: 400;
-  margin: 56px 0 20px; letter-spacing: -0.015em;
-  position: relative;
-}
-.case-body h2::before {
-  content: "§"; position: absolute; left: -28px; top: 10px;
-  color: var(--accent); font-size: 22px;
-}
-@media (max-width: 720px) { .case-body h2::before { display: none; } }
-.case-body h3 {
-  font-family: var(--font-display);
-  font-size: 24px; margin: 40px 0 12px; font-weight: 400;
-  color: var(--fg); font-style: italic;
-}
-.case-body h4 {
-  font-family: var(--font-mono); font-size: 12px;
-  letter-spacing: 0.08em; text-transform: uppercase;
-  color: var(--fg-dim); margin: 32px 0 8px; font-weight: 400;
-}
-.case-body p {
-  font-family: var(--font-display);
-  font-size: 19px; line-height: 1.65;
-  margin: 16px 0; color: var(--fg);
-}
-.case-body a { color: var(--accent); }
-.case-body a:hover { color: var(--accent-hover); }
-.case-body em { font-style: italic; color: var(--fg-muted); }
-.case-body strong { font-weight: 400; font-style: italic; color: var(--fg); }
-
-/* drop cap on the first paragraph of the first section */
-.case-body .drop-cap::first-letter {
-  font-family: var(--font-display);
-  font-size: 96px; line-height: 0.85;
-  float: left; padding: 8px 12px 0 0;
-  color: var(--accent);
-  font-style: italic;
-}
-
-/* lists — editorial bullets */
-.case-body ul, .case-body ol {
-  font-family: var(--font-display); font-size: 18px; line-height: 1.6;
-  color: var(--fg); padding-left: 0; list-style: none;
-  margin: 16px 0;
-}
-.case-body ul li {
-  padding: 6px 0 6px 28px; position: relative;
-  border-bottom: 1px dashed var(--line-soft);
-}
-.case-body ul li:last-child { border-bottom: 0; }
-.case-body ul li::before {
-  content: "§"; position: absolute; left: 4px; top: 6px;
-  color: var(--accent); font-family: var(--font-display);
-  font-size: 18px;
-}
-.case-body ol {
-  counter-reset: li;
-}
-.case-body ol li {
-  counter-increment: li;
-  padding: 10px 0 10px 44px; position: relative;
-  border-bottom: 1px dashed var(--line-soft);
-}
-.case-body ol li:last-child { border-bottom: 0; }
-.case-body ol li::before {
-  content: counter(li, decimal-leading-zero);
-  position: absolute; left: 0; top: 14px;
-  font-family: var(--font-mono); font-size: 11px;
-  color: var(--fg-dim); letter-spacing: 0.04em;
-}
-
-/* blockquote — pull quote */
-.case-body blockquote {
-  border-left: 2px solid var(--accent);
-  padding: 8px 0 8px 28px; margin: 32px 0;
-  font-family: var(--font-display); font-style: italic;
-  color: var(--fg-muted); font-size: 22px; line-height: 1.5;
-  max-width: 56ch;
-}
-.case-body blockquote p { font-family: inherit; font-size: inherit; line-height: inherit; color: inherit; margin: 0; font-style: inherit; }
-
-/* code — mono */
-.case-body pre {
-  font-family: var(--font-mono); font-size: 12.5px; line-height: 1.65;
-  background: var(--bg-sink); border: 1px solid var(--line);
-  padding: 20px; overflow-x: auto;
-  margin: 24px 0;
-  max-width: none; color: var(--fg);
-}
-.case-body code:not(pre code) {
-  font-family: var(--font-mono); font-size: 0.85em;
-  background: var(--bg-sink); padding: 2px 6px;
-  border: 1px solid var(--line); border-radius: 2px;
-  color: var(--fg);
-}
-
-/* tables — editorial */
-.case-body table {
-  width: 100%; border-collapse: collapse;
-  font-family: var(--font-mono); font-size: 12.5px;
-  margin: 24px 0;
-  color: var(--fg);
-}
-.case-body table th, .case-body table td {
-  text-align: left; padding: 10px 12px 10px 0;
-  border-bottom: 1px dashed var(--line-soft);
-  vertical-align: top;
-}
-.case-body table th {
-  color: var(--fg-dim); font-weight: 400;
-  letter-spacing: 0.04em; text-transform: lowercase;
-  border-bottom: 1px solid var(--line);
-  font-size: 11px;
-}
-.case-body table td.accent { color: var(--accent); }
-.case-body table td.check { color: var(--accent); text-align: center; width: 56px; }
-.case-body table td.dash { color: var(--fg-dim); text-align: center; width: 56px; }
-
-/* stat callout — big serif number + mono label */
-.case-stat-row {
-  display: grid; grid-template-columns: repeat(3, 1fr);
-  gap: 32px; padding: 40px 0;
-  border-top: 1px solid var(--line);
-  border-bottom: 1px solid var(--line);
-  margin: 48px 0;
-}
-.case-stat .n {
-  font-family: var(--font-display);
-  font-size: 64px; line-height: 1;
-  color: var(--accent); font-weight: 400;
-}
-.case-stat .l {
-  font-family: var(--font-mono); font-size: 12px;
-  color: var(--fg-muted); margin-top: 12px;
-  letter-spacing: 0.04em; text-transform: lowercase;
-  line-height: 1.5;
-}
-@media (max-width: 600px) {
-  .case-stat-row { grid-template-columns: 1fr; gap: 24px; }
-  .case-stat .n { font-size: 48px; }
-}
-
-/* prev / next case chapter nav */
-.case-nav {
-  display: grid; grid-template-columns: 1fr 1fr;
-  gap: 16px; margin-top: 72px;
-  border-top: 1px solid var(--line);
-  border-bottom: 1px solid var(--line);
-}
-.case-nav a {
-  padding: 28px 0;
-  font-family: var(--font-display); font-size: 18px;
-  color: var(--fg); text-decoration: none;
-  border-right: 1px solid var(--line);
-}
-.case-nav a:last-child { border-right: 0; text-align: right; }
-.case-nav a .label {
-  font-family: var(--font-mono); font-size: 11px;
-  color: var(--fg-dim); letter-spacing: 0.04em;
-  text-transform: lowercase; display: block; margin-bottom: 6px;
-}
-.case-nav a:hover { color: var(--accent); }
-.case-nav a:hover .label { color: var(--accent); }
-@media (max-width: 600px) {
-  .case-nav { grid-template-columns: 1fr; }
-  .case-nav a { border-right: 0; border-bottom: 1px solid var(--line); text-align: left !important; }
-  .case-nav a:last-child { border-bottom: 0; text-align: left; }
+  .work-row { grid-template-columns: 32px 1fr; gap: 12px; }
+  .work-row .blurb, .work-row .year { grid-column: 2; text-align: left; }
+  .work-row h3 { font-size: 26px; }
 }
 
 /* ====================================================
-   CMDK palette
+   WORK INDEX — case rows
+   ==================================================== */
+.work-page-head { display: grid; grid-template-columns: 1.4fr 1fr; gap: 64px; padding: 48px 0 40px; border-bottom: 1px solid var(--soft-rule); }
+.work-page-head h1 { font-family: var(--font-display); font-size: var(--fs-h1); line-height: 1; color: var(--ink); margin: 0; }
+.work-page-head .lead { font-family: var(--font-body); font-size: var(--fs-lead); color: var(--dim); align-self: end; line-height: var(--lh-lead); }
+
+.case-row {
+  display: grid; grid-template-columns: 48px 1.4fr 1fr 0.8fr 80px;
+  gap: 28px; padding: 32px 0;
+  border-top: 1px solid var(--soft-rule);
+  text-decoration: none; color: var(--ink);
+  align-items: start;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+.case-row:hover { background: var(--accent-soft); }
+.case-row .n { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--mute); padding-top: 10px; }
+.case-row h3 { font-family: var(--font-display); font-size: 36px; line-height: 1.05; letter-spacing: var(--tr-snug); margin: 0; color: var(--ink); display: inline; }
+.case-row .case-title-row { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
+.case-row .sub { font-family: var(--font-body); font-size: var(--fs-body); color: var(--dim); margin-top: 8px; font-style: italic; }
+.case-row .meta { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--mute); margin-top: 14px; text-transform: lowercase; }
+.case-row .col-label { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--mute); text-transform: lowercase; margin-bottom: 8px; }
+.case-row .pills { display: flex; gap: 6px; flex-wrap: wrap; }
+.case-row .pill { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--dim); padding: 3px 8px; border: 1px solid var(--rule); text-transform: lowercase; }
+.case-row .stack { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--dim); line-height: 1.7; text-transform: lowercase; }
+.case-row .read { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--mute); text-align: right; padding-top: 10px; }
+
+@media (max-width: 1080px) {
+  .case-row { grid-template-columns: 32px 1fr; }
+  .case-row > div:not(:nth-child(2)) { grid-column: 2; }
+  .case-row .read { text-align: left; padding-top: 0; }
+}
+
+.filter-bar {
+  margin-top: 48px; padding: 20px 0;
+  border-top: 1px solid var(--soft-rule);
+  border-bottom: 1px solid var(--soft-rule);
+  display: flex; gap: 24px; align-items: center; flex-wrap: wrap;
+  font-family: var(--font-mono); font-size: var(--fs-meta);
+  color: var(--mute); text-transform: lowercase;
+}
+.filter-bar .filter { color: var(--dim); border-bottom: 1px solid transparent; padding-bottom: 2px; cursor: pointer; }
+.filter-bar .filter.active { color: var(--ink); border-bottom-color: var(--accent); }
+.filter-bar .count { margin-left: auto; }
+
+/* ====================================================
+   PAGE HEADER — generic 2-col
+   ==================================================== */
+.page-head {
+  display: grid; grid-template-columns: 1.4fr 1fr;
+  gap: 64px; padding: 48px 0;
+  border-bottom: 1px solid var(--soft-rule);
+}
+.page-head h1 { font-family: var(--font-display); font-size: var(--fs-h1); line-height: 1; margin: 0; color: var(--ink); }
+.page-head .lead { font-family: var(--font-body); font-size: var(--fs-lead); color: var(--dim); align-self: end; line-height: var(--lh-lead); }
+@media (max-width: 860px) {
+  .page-head, .work-page-head { grid-template-columns: 1fr; gap: 24px; }
+  .page-head .lead, .work-page-head .lead { align-self: start; }
+}
+
+/* ====================================================
+   DOCS / NOTES list
+   ==================================================== */
+.doc-row, .note-row {
+  display: grid; grid-template-columns: 1.6fr 0.8fr 100px;
+  gap: 24px; padding: 24px 0;
+  border-bottom: 1px solid var(--soft-rule);
+  text-decoration: none; color: var(--ink); align-items: baseline;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+.doc-row:hover, .note-row:hover { background: var(--accent-soft); }
+.doc-row .title, .note-row .title {
+  font-family: var(--font-display); font-style: italic;
+  font-size: var(--fs-h3); line-height: var(--lh-snug);
+  color: var(--ink);
+}
+.doc-row .sub { font-family: var(--font-body); font-size: var(--fs-small); color: var(--dim); margin-top: 6px; }
+.doc-row .tag, .note-row .kind { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--mute); text-transform: lowercase; }
+.doc-row .read { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--mute); text-align: right; text-transform: lowercase; }
+
+.note-row { grid-template-columns: 120px 1fr 80px; }
+.note-row .date { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--mute); }
+.note-row .title { font-size: 22px; }
+.note-row .kind { color: var(--accent); text-align: right; }
+
+@media (max-width: 720px) {
+  .doc-row, .note-row { grid-template-columns: 1fr; gap: 6px; }
+  .doc-row .read, .doc-row .tag, .note-row .kind, .note-row .date { text-align: left; }
+}
+
+/* ====================================================
+   ABOUT / CONTACT side panels
+   ==================================================== */
+.split-2 {
+  display: grid; grid-template-columns: 1.4fr 1fr;
+  gap: 64px; padding: 56px 0;
+}
+.split-2--big-left { grid-template-columns: 1.5fr 1fr; }
+@media (max-width: 900px) { .split-2 { grid-template-columns: 1fr; gap: 32px; } }
+
+.side-card {
+  border: 1px solid var(--rule); background: var(--bone);
+  padding: 24px;
+}
+.side-card .sc-eyebrow { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--mute); text-transform: lowercase; }
+.side-card .sc-row {
+  display: grid; grid-template-columns: 120px 1fr;
+  padding: 8px 0; border-top: 1px solid var(--soft-rule);
+  font-family: var(--font-body); font-size: var(--fs-small);
+}
+.side-card .sc-row .k { color: var(--mute); font-family: var(--font-mono); font-size: var(--fs-meta); text-transform: lowercase; }
+.side-card .sc-row .v { color: var(--ink); }
+
+.elsewhere a {
+  display: flex; justify-content: space-between;
+  padding: 10px 0; border-top: 1px solid var(--soft-rule);
+  text-decoration: none; color: var(--ink);
+  font-family: var(--font-body); font-size: var(--fs-small);
+}
+.elsewhere a .k { color: var(--dim); font-family: var(--font-mono); font-size: var(--fs-meta); text-transform: lowercase; }
+
+/* hero variants */
+.hero-tall h1 {
+  font-family: var(--font-display);
+  font-size: 84px; line-height: 0.95; letter-spacing: -0.035em;
+  margin: 0; font-weight: 400; color: var(--ink);
+}
+.hero-tall h1 .em-accent { font-style: italic; color: var(--accent); }
+.hero-tall .lead { font-family: var(--font-body); font-size: var(--fs-lead); color: var(--dim); margin-top: 28px; max-width: 540px; line-height: var(--lh-lead); }
+
+/* short-list ordered */
+.belief-list {
+  font-family: var(--font-body); font-size: var(--fs-body);
+  line-height: 1.85; color: var(--dim); padding-left: 22px;
+  margin-top: 12px;
+}
+.belief-list li { margin: 4px 0; }
+.belief-list li::marker { color: var(--mute); font-family: var(--font-mono); font-size: var(--fs-meta); }
+
+/* ====================================================
+   LAB — asymmetric grid
+   ==================================================== */
+.lab-grid {
+  display: grid; grid-template-columns: repeat(6, 1fr);
+  gap: 14px; padding: 40px 0;
+}
+.lab-card {
+  border: 1px solid var(--rule); background: var(--bone);
+  padding: 18px; display: flex; flex-direction: column;
+  position: relative; overflow: hidden;
+  text-decoration: none; color: var(--ink);
+  transition: border-color var(--dur-fast) var(--ease-out);
+}
+.lab-card:hover { border-color: var(--accent); }
+.lab-card.accent { border-color: var(--accent); }
+.lab-card .lc-bg { position: absolute; inset: 0; opacity: 0.9; pointer-events: none; }
+.lab-card .lc-foot { position: relative; z-index: 1; margin-top: auto; padding: 8px 0; background: linear-gradient(to top, var(--bone), var(--bone) 60%, transparent); }
+.lab-card .lc-title { font-family: var(--font-display); font-size: 19px; font-style: italic; color: var(--ink); }
+.lab-card .lc-sub { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--dim); text-transform: lowercase; margin-top: 4px; }
+
+.lab-card.span-2 { grid-column: span 2; }
+.lab-card.span-3 { grid-column: span 3; }
+.lab-card.span-4 { grid-column: span 4; }
+.lab-card.h-220 { min-height: 220px; }
+.lab-card.h-280 { min-height: 280px; }
+
+@media (max-width: 980px) {
+  .lab-grid { grid-template-columns: repeat(3, 1fr); }
+  .lab-card.span-2, .lab-card.span-3, .lab-card.span-4 { grid-column: span 3; }
+}
+@media (max-width: 560px) {
+  .lab-grid { grid-template-columns: 1fr; }
+  .lab-card.span-2, .lab-card.span-3, .lab-card.span-4 { grid-column: span 1; }
+}
+
+/* ====================================================
+   JMNPR roster cards
+   ==================================================== */
+.roster {
+  display: grid; grid-template-columns: repeat(3, 1fr);
+  gap: 16px; margin-top: 18px;
+}
+.roster-card {
+  border: 1px solid var(--rule); background: var(--bone);
+  padding: 22px; min-height: 180px;
+  display: flex; flex-direction: column;
+}
+.roster-card .rc-head { display: flex; justify-content: space-between; align-items: baseline; }
+.roster-card .rc-n { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--mute); }
+.roster-card .rc-status { font-family: var(--font-mono); font-size: var(--fs-meta); text-transform: lowercase; }
+.roster-card .rc-status.shipped { color: var(--pos); }
+.roster-card .rc-status.beta { color: var(--accent); }
+.roster-card .rc-status.building { color: var(--warn); }
+.roster-card .rc-status.concepting, .roster-card .rc-status.redacted { color: var(--mute); }
+.roster-card .rc-name { font-family: var(--font-display); font-size: 28px; font-style: italic; color: var(--ink); margin-top: 14px; }
+.roster-card .rc-blurb { font-family: var(--font-body); font-size: var(--fs-small); color: var(--dim); margin-top: 10px; }
+@media (max-width: 980px) { .roster { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 560px) { .roster { grid-template-columns: 1fr; } }
+
+/* ====================================================
+   FOOTER
+   ==================================================== */
+.footer {
+  border-top: 1px solid var(--soft-rule);
+  padding: 32px var(--grid-pad) 28px;
+  margin-top: 56px;
+  display: flex; justify-content: space-between; align-items: flex-start;
+  flex-wrap: wrap; gap: 24px;
+  max-width: var(--grid-max); margin-left: auto; margin-right: auto;
+}
+.footer .brand-line {
+  font-family: var(--font-mono); font-size: 28px; font-weight: 500;
+  letter-spacing: -0.02em; color: var(--accent); line-height: 1;
+  display: inline-flex; align-items: baseline;
+}
+.footer .brand-line .caret {
+  display: inline-block; width: 0.55em; height: 0.95em;
+  background: var(--accent); margin-left: 2px;
+  transform: translateY(0.06em);
+  animation: ra-blink 1.06s steps(1) infinite;
+}
+.footer .role { font-family: var(--font-body); font-size: var(--fs-small); color: var(--dim); margin-top: 6px; }
+.footer .links { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--mute); margin-top: 18px; text-transform: lowercase; }
+.footer .links a { color: var(--mute); text-decoration: none; }
+.footer .links a:hover { color: var(--accent); }
+.footer .right { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--mute); text-align: right; text-transform: lowercase; line-height: 1.8; }
+.footer .right a { color: var(--mute); }
+.footer .right a:hover { color: var(--accent); }
+.footer .sign { color: var(--mute); }
+@media (max-width: 720px) {
+  .footer .right { text-align: left; }
+}
+
+/* ====================================================
+   COMMAND PALETTE — kept from prior site, restyled
    ==================================================== */
 .cmdk-overlay {
-  position: fixed; inset: 0;
-  background: rgba(15,11,8,0.72); backdrop-filter: blur(6px);
-  display: flex; align-items: flex-start; justify-content: center;
-  padding-top: 18vh; z-index: 100;
-  opacity: 0; visibility: hidden; pointer-events: none;
-  transition: opacity 120ms var(--ease-out), visibility 0s linear 120ms;
+  position: fixed; inset: 0; z-index: 200;
+  display: none; align-items: flex-start; justify-content: center;
+  background: rgba(12,12,14,0.66); backdrop-filter: blur(4px);
+  padding-top: 12vh;
 }
-.cmdk-overlay.open {
-  opacity: 1; visibility: visible; pointer-events: auto;
-  transition: opacity 120ms var(--ease-out), visibility 0s;
-}
+.cmdk-overlay.open { display: flex; }
 .cmdk {
-  width: min(640px, 92vw); background: var(--bg-raise);
-  border: 1px solid var(--line-strong);
+  width: min(640px, 92vw);
+  background: var(--bone); border: 1px solid var(--rule);
   box-shadow: var(--shadow-pop);
-  transform: translateY(-6px) scale(0.985);
-  transition: transform 160ms var(--ease-out);
 }
-.cmdk-overlay.open .cmdk { transform: translateY(0) scale(1); }
-@media (prefers-reduced-motion: reduce) {
-  .cmdk-overlay, .cmdk-overlay.open, .cmdk, .cmdk-overlay.open .cmdk {
-    transition: none !important; transform: none !important;
-  }
+#cmdk-input {
+  width: 100%; box-sizing: border-box;
+  background: transparent; border: 0; outline: 0;
+  padding: 18px 20px; color: var(--ink);
+  font-family: var(--font-mono); font-size: 14px;
+  border-bottom: 1px solid var(--rule);
 }
-.cmdk input {
-  width: 100%; background: transparent; border: 0; outline: 0;
-  padding: 14px 16px; font-family: var(--font-mono); font-size: 14px;
-  color: var(--fg); border-bottom: 1px solid var(--line);
-}
-.cmdk-results { max-height: 320px; overflow-y: auto; }
+.cmdk-results { max-height: 50vh; overflow-y: auto; }
 .cmdk-row {
-  display: flex; justify-content: space-between;
-  padding: 10px 16px; font-family: var(--font-mono); font-size: 13px;
-  color: var(--fg-muted); cursor: pointer;
+  display: flex; justify-content: space-between; align-items: baseline;
+  padding: 10px 20px; cursor: pointer;
+  font-family: var(--font-body); font-size: var(--fs-small); color: var(--ink);
 }
-.cmdk-row .path { color: var(--fg-dim); }
-.cmdk-row.selected {
-  background: var(--accent-dim);
-  border-left: 2px solid var(--accent);
-  color: var(--fg); padding-left: 14px;
-}
+.cmdk-row.selected { background: var(--accent-soft); }
+.cmdk-row .path { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--mute); }
 .cmdk-row .hit { color: var(--accent); }
 .cmdk-foot {
-  display: flex; gap: 16px; padding: 8px 16px;
-  border-top: 1px solid var(--line);
-  font-family: var(--font-mono); font-size: 11px; color: var(--fg-dim);
+  display: flex; gap: 14px; padding: 10px 16px;
+  border-top: 1px solid var(--rule);
+  font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--mute);
 }
 
-/* ====================================================
-   VIEW-SOURCE drawer
-   ==================================================== */
-.vs-scrim {
-  position: fixed; inset: 0; background: rgba(15,11,8,0.55);
-  opacity: 0; pointer-events: none; transition: opacity 200ms var(--ease-out);
-  z-index: 90;
-}
+/* view-source drawer */
+.vs-scrim { position: fixed; inset: 0; background: rgba(12,12,14,0.66); backdrop-filter: blur(2px); z-index: 190; opacity: 0; pointer-events: none; transition: opacity 200ms var(--ease-out); }
 .vs-scrim.open { opacity: 1; pointer-events: auto; }
 .vs-drawer {
   position: fixed; top: 0; right: 0; bottom: 0;
-  width: min(520px, 92vw);
-  background: var(--bg-raise); border-left: 1px solid var(--line-strong);
-  transform: translateX(100%); transition: transform 320ms var(--ease-out);
-  z-index: 91; display: flex; flex-direction: column;
+  width: min(640px, 92vw); background: var(--bone);
+  border-left: 1px solid var(--rule); z-index: 195;
+  transform: translateX(100%); transition: transform 240ms var(--ease-out);
+  display: flex; flex-direction: column;
 }
 .vs-drawer.open { transform: translateX(0); }
-.vs-head {
-  display: flex; justify-content: space-between; align-items: center;
-  padding: 14px 16px; border-bottom: 1px solid var(--line);
-}
-.vs-close {
-  background: transparent; border: 1px solid var(--line);
-  padding: 2px 8px; font-family: var(--font-mono); font-size: 11px;
-  color: var(--fg-muted); cursor: pointer;
-}
-.vs-close:hover { color: var(--accent); border-color: var(--accent); }
-.vs-pre {
-  margin: 0; flex: 1; overflow: auto; padding: 16px;
-  font-size: 12px; line-height: 18px;
-  background: var(--bg-sink); border: 0; max-width: none;
-}
-
-/* ====================================================
-   FOOTER — signed, editorial
-   ==================================================== */
-.footer {
-  border-top: 1px solid var(--line);
-  padding: 32px 0 48px; margin-top: 64px;
-  display: grid; grid-template-columns: 1fr 1fr; gap: 24px;
-  font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted);
-}
-.footer .sign {
-  font-family: var(--font-display); font-style: italic;
-  color: var(--fg); font-size: 16px; line-height: 1.5;
-}
-.footer .brand-line {
-  font-family: var(--font-display);
-  font-size: 22px; color: var(--fg); margin-bottom: 4px;
-}
-.footer .right { text-align: right; }
-.footer a { color: var(--fg-muted); }
-.footer a:hover { color: var(--accent); }
-@media (max-width: 600px) {
-  .footer { grid-template-columns: 1fr; }
-  .footer .right { text-align: left; }
-  .sb-clocks { display: none; }
-}
-
-/* ====================================================
-   GRID OVERLAY (g to toggle)
-   ==================================================== */
-.grid-overlay {
-  position: fixed; inset: 0; pointer-events: none; z-index: 99;
-  opacity: 0; transition: opacity 200ms;
-  display: grid; grid-template-columns: repeat(12, 1fr);
-  gap: 16px; padding: 0 32px; max-width: var(--grid-max); margin: 0 auto;
-}
-.grid-overlay.on { opacity: 1; }
-.grid-overlay > div {
-  background: rgba(232,106,78,0.06);
-  border-left: 1px dashed rgba(232,106,78,0.28);
-  border-right: 1px dashed rgba(232,106,78,0.28);
-}
-
-/* ====================================================
-   KONAMI toast
-   ==================================================== */
-.konami-toast {
-  position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%);
-  padding: 8px 16px; border: 1px solid #33FF66; color: #33FF66;
-  font-family: var(--font-mono); font-size: 13px;
-  background: var(--bg-raise); z-index: 200;
-}
-
-/* ====================================================
-   EF password gate
-   ==================================================== */
-.ef-gate {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 12px;
-  align-items: end;
-  padding: 20px 0;
-  max-width: 52ch;
-}
-.ef-gate .label {
-  display: block; grid-column: 1 / -1;
-  font-family: var(--font-mono); font-size: 11px;
-  color: var(--fg-dim); letter-spacing: 0.04em;
-  text-transform: lowercase;
-  margin-bottom: 4px;
-}
-.ef-gate input {
-  background: var(--bg-raise); border: 1px solid var(--line-strong);
-  padding: 12px 14px; font-family: var(--font-mono); font-size: 14px;
-  color: var(--fg);
-}
-.ef-gate input:focus { border-color: var(--accent); outline: none; }
-.ef-gate .cta { white-space: nowrap; }
-.ef-gate-err {
-  grid-column: 1 / -1;
-  min-height: 18px;
-  font-family: var(--font-mono); font-size: 12px;
-  color: var(--danger);
-}
-
-/* gated case-row chip on /work and home */
-.locked-chip {
-  display: inline-block; margin-left: 10px;
-  font-family: var(--font-mono); font-size: 10px;
-  letter-spacing: 0.06em; text-transform: uppercase;
-  color: var(--fg-dim);
-  border: 1px solid var(--line);
-  padding: 2px 7px; border-radius: var(--r-2);
-  vertical-align: 2px;
-}
-.work-row:hover .locked-chip { color: var(--accent); border-color: var(--accent-dim); }
-
-/* ====================================================
-   DOCS / LIBRARY — bookshelf + reader
-   ==================================================== */
-
-/* the shelf */
-.shelf {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(54px, 1fr));
-  gap: 8px;
-  padding: 32px 0 0 0;
-  position: relative;
-}
-.shelf::after {
-  content: "";
-  position: absolute; left: -8px; right: -8px; bottom: -1px;
-  height: 1px; background: var(--fg-dim);
-  box-shadow: 0 2px 0 var(--line);
-}
-@media (min-width: 720px) {
-  .shelf { grid-template-columns: repeat(auto-fit, minmax(64px, 72px)); gap: 10px; }
-}
-
-.book {
-  position: relative;
-  display: flex; flex-direction: column;
-  justify-content: space-between;
-  height: 280px;
-  padding: 14px 8px 16px;
-  background: var(--bg-raise);
-  border: 1px solid var(--line);
-  border-bottom: 0;
-  text-decoration: none;
-  color: var(--fg);
+.vs-head { display: flex; justify-content: space-between; align-items: center; padding: 14px 20px; border-bottom: 1px solid var(--rule); }
+.vs-close { background: transparent; border: 1px solid var(--rule); color: var(--dim); padding: 4px 8px; font-family: var(--font-mono); font-size: var(--fs-meta); cursor: pointer; }
+.vs-pre { flex: 1; overflow: auto; margin: 0; padding: 16px 20px; }
+.vs-pre code { display: block; white-space: pre; }
+.vs-handle {
+  position: absolute; top: 8px; right: 8px;
+  background: transparent; border: 1px solid var(--rule);
+  width: 24px; height: 24px; display: grid; place-items: center;
+  font-family: var(--font-mono); font-size: 11px; color: var(--mute);
   cursor: pointer;
-  transition: transform 240ms var(--ease-out), border-color 120ms var(--ease-out),
-              box-shadow 240ms var(--ease-out), background 120ms var(--ease-out);
-  transform-origin: bottom center;
-  overflow: hidden;
 }
-/* slight height/width variation so it reads like a real shelf */
-.book:nth-child(3n+1) { height: 272px; }
-.book:nth-child(5n+2) { height: 288px; }
-.book:nth-child(7n+3) { height: 264px; }
-.book:nth-child(4n+2) { background: var(--bg-sink); }
+.vs-handle:hover { color: var(--accent); border-color: var(--accent); }
 
-.book:hover {
-  transform: translateY(-8px) rotate(-1.2deg);
-  border-color: var(--accent);
-  box-shadow: 0 12px 24px rgba(0,0,0,0.4);
-  z-index: 2;
+/* grid overlay (debug) */
+.grid-overlay {
+  position: fixed; inset: 0; z-index: 100;
+  pointer-events: none; opacity: 0;
+  display: grid; grid-template-columns: repeat(12, 1fr);
+  max-width: var(--grid-max); margin: 0 auto;
+  gap: 16px; padding: 0 var(--grid-pad);
 }
-.book:nth-child(even):hover { transform: translateY(-8px) rotate(1.2deg); }
+.grid-overlay.on { opacity: 0.18; }
+.grid-overlay > div { background: var(--accent); height: 100%; }
 
-/* accent band at top — category colour */
-.book::before {
-  content: "";
-  position: absolute; top: 0; left: 0; right: 0;
-  height: 4px;
-  background: var(--accent);
-}
-.book[data-kind="adr"]::before       { background: var(--accent); }
-.book[data-kind="framework"]::before { background: var(--fg); }
-.book[data-kind="colophon"]::before  { background: var(--fg-muted); }
-.book[data-kind="brand"]::before     { background: var(--accent-press); }
-.book[data-kind="resume"]::before    { background: var(--live); }
-
-.book .kind {
-  font-family: var(--font-mono); font-size: 9px;
-  color: var(--fg-dim); letter-spacing: 0.12em;
-  text-transform: uppercase;
-  writing-mode: horizontal-tb;
-}
-.book .title {
-  font-family: var(--font-display);
-  color: var(--fg);
-  font-size: 17px; line-height: 1.1;
-  writing-mode: vertical-rl; transform: rotate(180deg);
-  margin: 8px auto;
-  flex: 1;
-  text-align: left;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-height: 210px;
-}
-.book:nth-child(3n+2) .title { font-style: italic; }
-
-.book .n {
-  font-family: var(--font-mono); font-size: 10px;
-  color: var(--fg-dim); letter-spacing: 0.04em;
-}
-
-/* legend / category key below shelf */
-.shelf-legend {
-  display: flex; flex-wrap: wrap; gap: 24px;
-  margin-top: 48px;
-  padding-top: 20px; border-top: 1px solid var(--line);
-  font-family: var(--font-mono); font-size: 11px;
-  color: var(--fg-dim); letter-spacing: 0.04em;
-}
-.shelf-legend .dot {
-  display: inline-block; width: 8px; height: 4px;
-  vertical-align: 1px; margin-right: 8px;
-}
-.shelf-legend .dot--adr { background: var(--accent); }
-.shelf-legend .dot--framework { background: var(--fg); }
-.shelf-legend .dot--colophon { background: var(--fg-muted); }
-.shelf-legend .dot--brand { background: var(--accent-press); }
-.shelf-legend .dot--resume { background: var(--live); }
-
-/* doc reader */
-.doc-layout {
-  display: grid;
-  grid-template-columns: 56px 1fr 56px;
-  gap: 32px;
-  max-width: var(--grid-max);
-  margin: 0 auto;
-}
-.doc-spine {
-  font-family: var(--font-mono); font-size: 11px; color: var(--fg-dim);
-  letter-spacing: 0.12em; text-transform: uppercase;
-  writing-mode: vertical-rl; transform: rotate(180deg);
-  padding-top: 80px;
-  white-space: nowrap;
-}
-@media (max-width: 860px) {
-  .doc-layout { grid-template-columns: 1fr; gap: 0; }
-  .doc-spine { display: none; }
-}
-.doc-head {
-  padding: 56px 0 32px; border-bottom: 1px solid var(--line);
-}
-.doc-head .kicker { margin-bottom: 12px; }
-.doc-head h1 {
-  font-family: var(--font-display);
-  font-size: 64px; line-height: 1.04; letter-spacing: -0.02em; font-weight: 400;
-  margin: 8px 0 0; max-width: 20ch;
-}
-.doc-head .subtitle {
-  font-family: var(--font-display); font-style: italic;
-  color: var(--fg-muted); font-size: 22px; line-height: 1.4;
-  max-width: 56ch; margin-top: 16px;
-}
-.doc-meta {
-  display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px 32px;
-  padding: 20px 0; border-top: 1px solid var(--line);
-  border-bottom: 1px solid var(--line); margin-top: 28px;
-}
-.doc-meta .k {
-  color: var(--fg-dim); letter-spacing: 0.04em; text-transform: lowercase;
-  font-family: var(--font-mono); font-size: 11px;
-  margin-bottom: 4px;
-}
-.doc-meta > div > div:last-child {
-  font-family: var(--font-mono); font-size: 13px; color: var(--fg);
-}
-
-/* doc body uses the same editorial rules as case-body */
-.doc-body { padding: 40px 0; max-width: 68ch; }
-.doc-body > *:first-child { margin-top: 0; }
-.doc-body h2 {
-  font-family: var(--font-display);
-  font-size: 32px; line-height: 1.12; font-weight: 400;
-  margin: 48px 0 16px; letter-spacing: -0.015em;
-  position: relative;
-}
-.doc-body h2::before {
-  content: "§"; position: absolute; left: -28px; top: 8px;
-  color: var(--accent); font-size: 20px;
-}
-@media (max-width: 720px) { .doc-body h2::before { display: none; } }
-.doc-body h3 {
-  font-family: var(--font-display);
-  font-size: 22px; margin: 36px 0 12px; font-weight: 400;
-  color: var(--fg); font-style: italic;
-}
-.doc-body h4 {
-  font-family: var(--font-mono); font-size: 12px;
-  letter-spacing: 0.08em; text-transform: uppercase;
-  color: var(--fg-dim); margin: 28px 0 8px; font-weight: 400;
-}
-.doc-body p {
-  font-family: var(--font-display);
-  font-size: 18px; line-height: 1.65;
-  margin: 14px 0; color: var(--fg);
-}
-.doc-body a { color: var(--accent); }
-.doc-body em { font-style: italic; color: var(--fg-muted); }
-.doc-body strong { font-weight: 400; font-style: italic; color: var(--fg); }
-
-.doc-body .drop-cap::first-letter {
-  font-family: var(--font-display);
-  font-size: 88px; line-height: 0.85;
-  float: left; padding: 6px 12px 0 0;
-  color: var(--accent);
-  font-style: italic;
-}
-
-.doc-body ul, .doc-body ol {
-  font-family: var(--font-display); font-size: 18px; line-height: 1.6;
-  color: var(--fg); padding-left: 0; list-style: none; margin: 14px 0;
-}
-.doc-body ul li {
-  padding: 6px 0 6px 28px; position: relative;
-  border-bottom: 1px dashed var(--line-soft);
-}
-.doc-body ul li:last-child { border-bottom: 0; }
-.doc-body ul li::before {
-  content: "§"; position: absolute; left: 4px; top: 6px;
-  color: var(--accent); font-family: var(--font-display); font-size: 18px;
-}
-.doc-body ol { counter-reset: li; }
-.doc-body ol li {
-  counter-increment: li;
-  padding: 10px 0 10px 44px; position: relative;
-  border-bottom: 1px dashed var(--line-soft);
-}
-.doc-body ol li:last-child { border-bottom: 0; }
-.doc-body ol li::before {
-  content: counter(li, decimal-leading-zero);
-  position: absolute; left: 0; top: 14px;
-  font-family: var(--font-mono); font-size: 11px;
-  color: var(--fg-dim); letter-spacing: 0.04em;
-}
-
-.doc-body blockquote {
-  border-left: 2px solid var(--accent);
-  padding: 6px 0 6px 24px; margin: 28px 0;
-  font-family: var(--font-display); font-style: italic;
-  color: var(--fg-muted); font-size: 21px; line-height: 1.5;
-  max-width: 56ch;
-}
-
-.doc-body pre {
-  font-family: var(--font-mono); font-size: 12.5px; line-height: 1.65;
-  background: var(--bg-sink); border: 1px solid var(--line);
-  padding: 20px; overflow-x: auto;
-  margin: 20px 0; max-width: none; color: var(--fg);
-}
-.doc-body code:not(pre code) {
-  font-family: var(--font-mono); font-size: 0.85em;
-  background: var(--bg-sink); padding: 2px 6px;
-  border: 1px solid var(--line); border-radius: 2px; color: var(--fg);
-}
-
-/* doc footer nav */
-.doc-nav {
-  display: grid; grid-template-columns: 1fr 1fr;
-  gap: 16px; margin-top: 56px;
-  border-top: 1px solid var(--line);
-  border-bottom: 1px solid var(--line);
-}
-.doc-nav a {
-  padding: 24px 0;
-  font-family: var(--font-display); font-size: 18px;
-  color: var(--fg); text-decoration: none;
-  border-right: 1px solid var(--line);
-}
-.doc-nav a:last-child { border-right: 0; text-align: right; }
-.doc-nav a .label {
-  font-family: var(--font-mono); font-size: 11px;
-  color: var(--fg-dim); letter-spacing: 0.04em;
-  text-transform: lowercase; display: block; margin-bottom: 6px;
-}
-.doc-nav a:hover { color: var(--accent); }
-.doc-nav a:hover .label { color: var(--accent); }
-@media (max-width: 600px) {
-  .doc-nav { grid-template-columns: 1fr; }
-  .doc-nav a { border-right: 0; border-bottom: 1px solid var(--line); text-align: left !important; }
-  .doc-nav a:last-child { border-bottom: 0; text-align: left; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .book, .book:hover { transform: none !important; transition: none !important; }
+/* konami toast */
+.konami-toast {
+  position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
+  background: var(--accent); color: var(--accent-ink);
+  padding: 10px 18px; border-radius: 0;
+  font-family: var(--font-mono); font-size: var(--fs-small);
+  z-index: 300;
 }
 
 /* ====================================================
-   TERMINAL (404)
+   404
    ==================================================== */
-.term {
-  font-family: var(--font-mono); font-size: 14px; line-height: 22px;
-  border: 1px solid var(--line); padding: 16px; min-height: 420px;
-  background: var(--bg-sink);
-}
-.tprompt { color: var(--accent); }
-.tout { color: var(--fg-muted); }
-.tin { color: var(--fg); }
-.tinput-row { display: flex; margin-top: 4px; }
-.tinput-row input {
-  flex: 1; background: transparent; border: 0; outline: 0;
-  font: inherit; color: var(--fg);
-}
+.notfound { padding: 80px 0; text-align: center; }
+.notfound .eyebrow { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--accent); text-transform: lowercase; }
+.notfound h1 { font-family: var(--font-display); font-size: 144px; font-style: italic; color: var(--ink); margin: 24px 0 0; line-height: 0.95; }
+.notfound .lead { font-family: var(--font-body); font-size: var(--fs-lead); color: var(--dim); margin: 24px auto 0; max-width: 540px; line-height: var(--lh-lead); }
+.notfound .links { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; margin-top: 40px; }
+.notfound .links a { font-family: var(--font-body); font-size: var(--fs-small); padding: 10px 16px; border: 1px solid var(--rule); color: var(--ink); text-decoration: none; }
+.notfound .console { margin-top: 56px; max-width: 600px; margin-left: auto; margin-right: auto; text-align: left; border: 1px solid var(--rule); padding: 18px; font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--mute); line-height: 1.8; }
+.notfound .console .pos { color: var(--dim); }
 
 /* ====================================================
-   PRINT — case studies + docs print like real editorial
+   CASE STUDY — editorial reading spread
    ==================================================== */
-@media print {
-  @page { margin: 2cm 2cm 2.5cm 2cm; }
+.case-progress { position: fixed; top: 0; left: 0; right: 0; height: 2px; z-index: 200; pointer-events: none; }
+.case-progress .bar { height: 100%; width: 0%; background: var(--accent); transition: width 80ms linear; }
 
-  /* paper-white, ink-black — don't burn through a print cartridge */
-  html, body {
-    background: #fff !important;
-    background-image: none !important;
-    color: #111 !important;
-    font-size: 11pt;
-    line-height: 1.55;
-  }
-
-  /* strip all chrome */
-  .status-bar, .nav, .footer, .footer *,
-  #grid-overlay, .skip-link,
-  .cmdk-overlay, .vs-scrim, .vs-drawer, .konami-toast,
-  .case-progress, .case-spine, .doc-spine,
-  .case-nav, .doc-nav,
-  .vs-handle, .vs-hint,
-  .signal-bar, .sb-clocks { display: none !important; }
-
-  .wrap { max-width: 100%; padding: 0; }
-  main, .case-layout, .doc-layout { display: block; }
-  .case-content { max-width: 100%; }
-
-  /* editorial type in print */
-  h1, h2, h3, h4 { color: #111 !important; }
-  a { color: #111 !important; text-decoration: none; }
-  a[href^="http"]::after,
-  a[href^="mailto:"]::after {
-    content: " (" attr(href) ")";
-    font-family: var(--font-mono);
-    font-size: 9pt;
-    color: #555;
-    word-break: break-all;
-  }
-
-  /* accent survives — in CMYK-safe terracotta */
-  .em-serif, .kicker, .case-head .kicker, .doc-head .kicker,
-  .case-body h2::before, .doc-body h2::before,
-  .case-body ul li::before, .doc-body ul li::before,
-  .case-stat .n, blockquote, .case-stack-row .ver {
-    color: #A84A2E !important;
-  }
-  blockquote { border-left: 2px solid #A84A2E !important; }
-
-  /* hairlines print as thin grey rules */
-  .case-head, .case-meta, .case-stack,
-  .doc-head, .doc-meta,
-  .case-body ul li, .case-body ol li,
-  .doc-body ul li, .doc-body ol li,
-  .case-stack-row, .live-row, .work-row,
-  .lab-row, .note-row {
-    border-color: #ccc !important;
-  }
-
-  /* page breaks before major sections */
-  .case-body h2, .doc-body h2 { page-break-before: auto; break-before: auto; }
-  .case-body h2 + *, .doc-body h2 + * { page-break-before: avoid; break-before: avoid; }
-  .case-body blockquote, .doc-body blockquote { page-break-inside: avoid; }
-  .case-body pre, .doc-body pre { page-break-inside: avoid; }
-  .case-stat-row { page-break-inside: avoid; border-color: #ccc !important; }
-
-  /* hide the EF password gate in print */
-  .ef-gate, .ef-gate-err, #ef-gate-form { display: none !important; }
-
-  /* hero section on case-study gets a proper top margin */
-  .case-head { padding-top: 0; }
-
-  /* hide non-essential stuff on non-case pages */
-  body[data-page="home"] .hero .signal-bar,
-  body[data-page="home"] .ship-log,
-  body[data-page="home"] .now-block { display: none !important; }
-
-  /* show a small URL header on every printed page via title */
-  .case-head h1::before,
-  .doc-head h1::before {
-    content: "raghavahuja.com · ";
-    font-family: var(--font-mono);
-    font-size: 10pt;
-    color: #888;
-    font-weight: 400;
-    font-style: normal;
-    letter-spacing: 0.04em;
-    text-transform: lowercase;
-    display: block;
-    margin-bottom: 8px;
+.case-layout {
+  display: grid; grid-template-columns: 56px 1fr 56px;
+  gap: 32px; max-width: var(--grid-max);
+  margin: 0 auto; padding: 0 var(--grid-pad);
+}
+@media (min-width: 1100px) {
+  .case-layout.has-toc { grid-template-columns: 56px minmax(0, 1fr) 220px; }
+}
+.case-toc { display: none; }
+@media (min-width: 1100px) {
+  .case-layout.has-toc .case-toc {
+    display: block; position: sticky; top: 32px;
+    align-self: start; padding-top: 80px;
+    max-height: calc(100vh - 64px); overflow-y: auto;
   }
 }
+.case-toc .label { font-family: var(--font-mono); font-size: 10px; color: var(--mute); letter-spacing: 0.12em; text-transform: lowercase; margin-bottom: 14px; }
+.case-toc ol { list-style: none; padding: 0; margin: 0; counter-reset: toc; }
+.case-toc li { counter-increment: toc; padding: 4px 0 4px 28px; position: relative; font-family: var(--font-display); font-size: 14px; line-height: 1.4; border-left: 1px solid var(--rule); }
+.case-toc li::before { content: counter(toc, decimal-leading-zero); position: absolute; left: 8px; top: 6px; font-family: var(--font-mono); font-size: 9px; color: var(--mute); }
+.case-toc a { color: var(--dim); text-decoration: none; display: block; padding: 2px 0; }
+.case-toc a:hover { color: var(--accent); }
+.case-toc li.active { border-left-color: var(--accent); }
+.case-toc li.active a { color: var(--ink); }
+.case-toc li.active::before { color: var(--accent); }
+.case-spine {
+  font-family: var(--font-mono); font-size: 11px; color: var(--mute);
+  letter-spacing: 0.12em; text-transform: lowercase;
+  writing-mode: vertical-rl; transform: rotate(180deg);
+  padding-top: 80px; white-space: nowrap;
+}
+.case-content { min-width: 0; }
+@media (max-width: 1100px) { .case-layout { grid-template-columns: 1fr; padding: 0 var(--grid-pad); } .case-spine { display: none; } }
 
-/* signal bar (decorative hero stripe) */
-.signal-bar { height: 2px; margin-top: 56px; background: var(--line); position: relative; overflow: hidden; }
-.signal-fill {
-  position: absolute; top: 0; left: 0; height: 100%; width: 30%;
-  background: linear-gradient(90deg, transparent, var(--accent), transparent);
-  animation: signal 3.2s linear infinite;
+.case-head { padding: 56px 0 32px; border-bottom: 1px solid var(--soft-rule); }
+.case-head .kicker { color: var(--accent); }
+.case-head h1 {
+  font-family: var(--font-display);
+  font-size: 84px; line-height: 0.95;
+  letter-spacing: -0.035em; font-weight: 400;
+  margin: 14px 0 0; color: var(--ink);
 }
-@keyframes signal { 0% { transform: translateX(-100%); } 100% { transform: translateX(420%); } }
-@media (prefers-reduced-motion: reduce) {
-  .signal-fill { animation: none; width: 100%; opacity: 0.4; }
-}
+.case-head .subtitle { font-family: var(--font-body); font-size: var(--fs-lead); color: var(--dim); max-width: 56ch; margin-top: 16px; line-height: var(--lh-lead); }
 
-/* responsive hero scale-down */
-@media (max-width: 900px) {
-  .hero h1 { font-size: 72px; }
+.case-meta { display: grid; grid-template-columns: repeat(2, 1fr); gap: 20px 32px; padding: 24px 0; border-top: 1px solid var(--soft-rule); border-bottom: 1px solid var(--soft-rule); margin-top: 32px; }
+.case-meta .k { color: var(--mute); letter-spacing: 0.04em; text-transform: lowercase; font-family: var(--font-mono); font-size: var(--fs-meta); margin-bottom: 4px; }
+.case-meta > div > div:last-child { font-family: var(--font-mono); font-size: var(--fs-small); color: var(--ink); line-height: 1.55; }
+@media (min-width: 720px) { .case-meta { grid-template-columns: repeat(4, 1fr); } }
+
+.case-stack { padding: 24px 0; border-bottom: 1px solid var(--soft-rule); }
+.case-stack .label { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--mute); letter-spacing: 0.12em; text-transform: lowercase; margin-bottom: 14px; }
+.case-stack-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 4px 24px; font-family: var(--font-mono); font-size: 12.5px; }
+.case-stack-row { display: grid; grid-template-columns: 1fr auto; padding: 6px 0; border-bottom: 1px dashed var(--soft-rule); color: var(--ink); }
+.case-stack-row .ver { color: var(--accent); }
+
+.case-body { padding: 40px 0; max-width: 68ch; }
+.case-body > *:first-child { margin-top: 0; }
+.case-body h2 { font-family: var(--font-display); font-size: var(--fs-h2); line-height: 1.1; font-weight: 400; margin: 56px 0 20px; letter-spacing: -0.02em; position: relative; color: var(--ink); }
+.case-body h2::before { content: "§"; position: absolute; left: -28px; top: 8px; color: var(--accent); font-size: 22px; }
+@media (max-width: 720px) { .case-body h2::before { display: none; } }
+.case-body h3 { font-family: var(--font-display); font-size: 24px; margin: 40px 0 12px; font-weight: 400; color: var(--ink); font-style: italic; }
+.case-body h4 { font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.08em; text-transform: lowercase; color: var(--mute); margin: 32px 0 8px; font-weight: 400; }
+.case-body p { font-family: var(--font-body); font-size: 17px; line-height: 1.7; margin: 16px 0; color: var(--ink); }
+.case-body a { color: var(--accent); }
+.case-body em { font-style: italic; color: var(--dim); }
+.case-body strong { font-weight: 500; color: var(--ink); }
+.case-body ul, .case-body ol { font-family: var(--font-body); font-size: 16px; line-height: 1.7; color: var(--ink); padding-left: 0; list-style: none; margin: 16px 0; }
+.case-body ul li { padding: 6px 0 6px 28px; position: relative; border-bottom: 1px dashed var(--soft-rule); }
+.case-body ul li:last-child { border-bottom: 0; }
+.case-body ul li::before { content: "§"; position: absolute; left: 4px; top: 6px; color: var(--accent); font-family: var(--font-display); }
+.case-body ol { counter-reset: li; }
+.case-body ol li { counter-increment: li; padding: 10px 0 10px 44px; position: relative; border-bottom: 1px dashed var(--soft-rule); }
+.case-body ol li:last-child { border-bottom: 0; }
+.case-body ol li::before { content: counter(li, decimal-leading-zero); position: absolute; left: 0; top: 14px; font-family: var(--font-mono); font-size: 11px; color: var(--mute); letter-spacing: 0.04em; }
+.case-body blockquote { border-left: 2px solid var(--accent); padding: 8px 0 8px 28px; margin: 32px 0; font-family: var(--font-display); font-style: italic; color: var(--ink); font-size: 22px; line-height: 1.45; }
+
+.case-nav { padding: 40px 0; border-top: 1px solid var(--soft-rule); margin-top: 40px; }
+.case-nav a { display: flex; justify-content: space-between; align-items: baseline; text-decoration: none; color: var(--ink); padding: 20px 0; }
+.case-nav .label { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--mute); text-transform: lowercase; }
+.case-nav .next-title { font-family: var(--font-display); font-size: var(--fs-h2); margin-top: 6px; color: var(--ink); }
+.case-nav .next-title em { font-style: italic; color: var(--dim); }
+.case-nav .arrow { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--accent); }
+
+/* metric ledger */
+.metric-ledger {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  border-bottom: 1px solid var(--soft-rule);
 }
-@media (max-width: 600px) {
-  .hero h1 { font-size: 56px; line-height: 1.06; }
-  .hero { padding: 48px 0 40px; }
-  .case-head h1 { font-size: 52px; }
-  .section-head h2 { font-size: 28px; }
-  .cta-hint { display: none; }
-  .hero-ctas { gap: 10px; }
-  .cta { padding: 10px 14px; font-size: 12.5px; }
-}
+.metric-ledger .cell { padding: 32px 24px 32px 0; border-right: 1px solid var(--soft-rule); }
+.metric-ledger .cell:first-child { padding-left: 0; }
+.metric-ledger .cell:last-child { border-right: 0; padding-right: 0; }
+.metric-ledger .v { font-family: var(--font-display); font-size: 44px; font-style: italic; color: var(--ink); line-height: 1; }
+.metric-ledger .l { font-family: var(--font-mono); font-size: var(--fs-meta); color: var(--mute); margin-top: 6px; text-transform: lowercase; }
+@media (max-width: 720px) { .metric-ledger { grid-template-columns: repeat(2, 1fr); } .metric-ledger .cell:nth-child(2) { border-right: 0; padding-right: 0; } }

--- a/site.js
+++ b/site.js
@@ -10,45 +10,50 @@
 
   // ---------- shared chrome injection ----------
   function mountChrome() {
-    // status bar — editorial masthead
-    if (!document.querySelector('.status-bar')) {
-      const sb = document.createElement('div');
-      sb.className = 'status-bar';
-      sb.setAttribute('role', 'status');
-      sb.innerHTML =
-        '<span class="sb-left"><span class="sb-dot"></span> vol. iv · no. 3 · <span class="em-accent">portfolio · night ed.</span></span>' +
-        '<span class="sb-clocks">' +
-          '<span>jamanapaar <b id="clk-mum">--:--</b></span>' +
+    // masthead — vol/no editorial strip (3 columns)
+    if (!document.querySelector('.masthead')) {
+      const mh = document.createElement('div');
+      mh.className = 'masthead';
+      mh.setAttribute('role', 'status');
+      mh.innerHTML =
+        '<div class="mh-vol">vol. iv · no. 4 · portfolio</div>' +
+        '<div class="mh-mid">raghavahuja.com</div>' +
+        '<div class="mh-clocks">' +
+          '<span>jamnapaar <b id="clk-mum">--:--</b></span>' +
           '<span>brooklyn <b id="clk-nyc">--:--</b></span>' +
-        '</span>';
-      document.body.insertBefore(sb, document.body.firstChild);
+        '</div>';
+      document.body.insertBefore(mh, document.body.firstChild);
     }
 
-    // nav — editorial brand, period accent
+    // nav — raghav_ blinking caret + links + day/night + ⌘K
     const navMount = document.getElementById('nav-mount');
     if (navMount) {
       const items = [
+        ['index','index.html','home'],
         ['work','work.html'],
         ['docs','docs.html'],
         ['lab','lab.html'],
-        ['writing','notes.html','notes'],  // label 'writing', but page is 'notes'
+        ['writing','notes.html','notes'],
         ['about','about.html'],
         ['contact','contact.html'],
       ];
       navMount.outerHTML = '<nav class="nav" aria-label="primary">' +
         '<div class="nav-left">' +
-          '<a href="index.html" class="brand">raghav ahuja<span class="caret">.</span></a>' +
-          '<div class="nav-links">' +
-            items.map((it) => {
-              const [l, h, pg] = it;
-              const key = pg || l;
-              return `<a href="${h}"${active===key?' class="active"':''}>${l}</a>`;
-            }).join('') +
-          '</div>' +
+          '<a href="index.html" class="brand" aria-label="raghavahuja.com — home">raghav_<span class="caret" aria-hidden="true"></span></a>' +
+        '</div>' +
+        '<div class="nav-links">' +
+          items.map((it) => {
+            const [l, h, pg] = it;
+            const key = pg || l;
+            return `<a href="${h}"${active===key?' class="active"':''}>${l}</a>`;
+          }).join('') +
         '</div>' +
         '<div class="nav-right">' +
-          '<button id="cmdk-trigger" class="nav-search" aria-label="Open command palette">' +
-            '<span class="label-chrome">go anywhere</span><kbd class="kbd">⌘K</kbd>' +
+          '<button id="theme-toggle" class="nav-btn" aria-label="Toggle day/night theme" type="button">' +
+            '<span class="theme-label">☾ night</span>' +
+          '</button>' +
+          '<button id="cmdk-trigger" class="nav-btn nav-btn--solid nav-search" aria-label="Open command palette" type="button">' +
+            '<span>go anywhere</span><span class="kbd">⌘K</span>' +
           '</button>' +
           '<button class="nav-toggle" aria-label="Menu" aria-expanded="false" aria-controls="nav-links">' +
             '<span class="nav-toggle-bar"></span><span class="nav-toggle-bar"></span><span class="nav-toggle-bar"></span>' +
@@ -62,9 +67,9 @@
     if (footMount) {
       footMount.outerHTML = '<footer class="footer">' +
         '<div>' +
-          '<div class="brand-line">raghav ahuja</div>' +
-          '<div>design engineer · brooklyn</div>' +
-          '<div style="margin-top: 10px;">' +
+          '<div class="brand-line">raghav_<span class="caret" aria-hidden="true"></span></div>' +
+          '<div class="role">design engineer · brooklyn</div>' +
+          '<div class="links">' +
             '<a href="mailto:work.raghavahuja@gmail.com">work.raghavahuja@gmail.com</a> · ' +
             '<a href="https://github.com/ahujatries">github</a> · ' +
             '<a href="https://linkedin.com/in/raghav-ahuja">linkedin</a> · ' +
@@ -72,10 +77,10 @@
           '</div>' +
         '</div>' +
         '<div class="right">' +
-          '<div class="sign">— written, designed, shipped by one person. night edition.</div>' +
-          '<div style="margin-top: 10px;">set in Instrument Serif &amp; JetBrains Mono</div>' +
-          '<div style="color: var(--fg-dim);">build <span id="build-sha" style="color: var(--accent);">—</span> · <span id="build-deployed">shipped recently</span></div>' +
-          '<div style="color: var(--fg-dim);" id="reader-tz"></div>' +
+          '<div class="sign">— written, designed, shipped<br>by one person.</div>' +
+          '<div style="margin-top: 10px;">set in fraunces, geist &amp; jetbrains mono.</div>' +
+          '<div style="margin-top: 10px;">build <span id="build-sha">—</span> · <span id="build-deployed">shipped recently</span></div>' +
+          '<div id="reader-tz"></div>' +
         '</div>' +
       '</footer>';
     }
@@ -134,10 +139,10 @@
 
   mountChrome();
 
-  // ---------- home brand active state ----------
+  // ---------- home active state — index nav link ----------
   if (active === 'home') {
-    const brand = document.querySelector('.nav .brand');
-    if (brand) brand.classList.add('active');
+    const homeLink = document.querySelector('.nav-links a[href="index.html"]');
+    if (homeLink) homeLink.classList.add('active');
   }
 
   // ---------- mobile nav toggle ----------
@@ -353,13 +358,27 @@
   });
 
   // ---------- theme toggle ----------
+  function currentTheme() {
+    const explicit = document.documentElement.getAttribute('data-theme');
+    if (explicit) return explicit;
+    return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+  }
+  function setThemeLabel() {
+    const btn = document.getElementById('theme-toggle');
+    if (!btn) return;
+    const lbl = btn.querySelector('.theme-label');
+    if (!lbl) return;
+    lbl.textContent = currentTheme() === 'dark' ? '☾ night' : '☀ day';
+  }
   function toggleTheme() {
-    const cur = document.documentElement.getAttribute('data-theme');
-    const next = cur === 'light' ? 'dark' : 'light';
+    const next = currentTheme() === 'light' ? 'dark' : 'light';
     document.documentElement.setAttribute('data-theme', next);
     try { localStorage.setItem('theme', next); } catch (e) {}
+    setThemeLabel();
     track('theme:toggle', { to: next });
   }
+  setThemeLabel();
+  document.getElementById('theme-toggle')?.addEventListener('click', toggleTheme);
   document.addEventListener('keydown', (e) => {
     if (isTypingTarget(e.target)) return;
     if (e.key === 't') toggleTheme();

--- a/tokens.css
+++ b/tokens.css
@@ -1,110 +1,98 @@
 /* =============================================================
    raghavahuja.com — tokens
-   Direction A · Dark — burnt ink + terracotta · candlelit editorial
+   Folio · vol. iv · no. 4 — cobalt accent · editorial light/dark
+   Type: Fraunces (display) × Geist (body) × JetBrains Mono (chrome)
    ============================================================= */
 
-/* self-hosted — Geist kept as fallback for future variant swap; Instrument
-   Serif is the display + body face for Direction A; JetBrains Mono is chrome. */
-@font-face {
-  font-family: 'Instrument Serif';
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: url('./fonts/InstrumentSerif-Regular.woff2') format('woff2');
-}
-@font-face {
-  font-family: 'Instrument Serif';
-  font-style: italic;
-  font-weight: 400;
-  font-display: swap;
-  src: url('./fonts/InstrumentSerif-Italic.woff2') format('woff2');
-}
-@font-face {
-  font-family: 'Geist';
-  font-style: normal;
-  font-weight: 400 700;
-  font-display: swap;
-  src: url('./fonts/Geist.woff2') format('woff2');
-}
-@font-face {
-  font-family: 'JetBrains Mono';
-  font-style: normal;
-  font-weight: 400 700;
-  font-display: swap;
-  src: url('./fonts/JetBrainsMono.woff2') format('woff2');
-}
+/* fonts pulled from Google Fonts via the @import in site.css */
 
 :root {
   /* ---------- TYPE FAMILIES ---------- */
-  /* Instrument Serif for display + body. Mono stays JBM. Geist is a fallback. */
-  --font-display: 'Instrument Serif', 'Playfair Display', Georgia, serif;
-  --font-body:    'Instrument Serif', 'Playfair Display', Georgia, serif;
+  --font-display: 'Fraunces', 'Iowan Old Style', Georgia, serif;
+  --font-body:    'Geist', system-ui, -apple-system, 'Segoe UI', sans-serif;
   --font-mono:    'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
 
-  /* ---------- TYPE SCALE (4px baseline) ---------- */
-  --fs-xs:    12px; --lh-xs:    16px;
-  --fs-sm:    14px; --lh-sm:    20px;
-  --fs-base:  17px; --lh-base:  28px;   /* body — serif wants more air */
-  --fs-md:    21px; --lh-md:    32px;
-  --fs-lg:    28px; --lh-lg:    36px;
-  --fs-xl:    38px; --lh-xl:    44px;
-  --fs-2xl:   48px; --lh-2xl:   52px;
-  --fs-3xl:   64px; --lh-3xl:   68px;
-  --fs-4xl:   88px; --lh-4xl:   92px;
-  --fs-5xl:   96px; --lh-5xl:   98px;   /* hero display */
+  /* ---------- TYPE SCALE ---------- */
+  --fs-micro:  10px;
+  --fs-meta:   11px;
+  --fs-small:  13px;
+  --fs-body:   15px;
+  --fs-lead:   19px;
+  --fs-h3:     26px;
+  --fs-h2:     38px;
+  --fs-h1:     56px;
+  --fs-hero:   88px;
+
+  --lh-tight:  1.0;
+  --lh-snug:   1.15;
+  --lh-base:   1.6;
+  --lh-lead:   1.55;
+  --lh-meta:   1.4;
 
   /* ---------- TYPE WEIGHTS ---------- */
   --fw-regular: 400;
   --fw-medium:  500;
   --fw-semi:    600;
-  --fw-bold:    700;
 
   /* ---------- TRACKING ---------- */
   --tr-tight:   -0.025em;
+  --tr-snug:    -0.015em;
   --tr-normal:  0;
-  --tr-wide:    0.04em;
-  --tr-wider:   0.08em;
+  --tr-wide:    0.06em;
+  --tr-wider:   0.10em;
   --tr-widest:  0.12em;
 
-  /* ---------- COLORS — Direction A Dark: burnt ink + warm cream ---------- */
-  --bg:         #15110D;   /* paper — burnt ink, warm near-black */
-  --bg-raise:   #1E1812;   /* one step up for chips/keycap */
-  --bg-sink:    #0F0B08;   /* code wells */
-  --fg:         #EDE3CE;   /* warm cream — main text */
-  --fg-muted:   #A89A83;   /* secondary */
-  --fg-dim:     #6F6452;   /* tertiary */
-  --fg-faint:   #4A4234;   /* disabled */
+  /* ---------- COLORS — DARK (default) · cobalt + bone ---------- */
+  --paper:    #0c0c0e;
+  --bone:     #16161a;
+  --sub:      #1e1e23;
 
-  --line:        rgba(237,227,206,0.18);
-  --line-strong: rgba(237,227,206,0.30);
-  --line-soft:   rgba(237,227,206,0.08);
+  --rule:        rgba(245, 240, 230, 0.10);
+  --soft-rule:   rgba(245, 240, 230, 0.06);
+  --strong-rule: rgba(245, 240, 230, 0.18);
 
-  --selection:  rgba(232, 106, 78, 0.35);
+  --ink:    #f5f0e6;
+  --dim:    rgba(245, 240, 230, 0.62);
+  --mute:   rgba(245, 240, 230, 0.38);
 
-  /* ---------- ACCENT: terracotta ---------- */
-  --accent:          #E86A4E;    /* brightened for dark-mode contrast */
-  --accent-hover:    #F08B74;
-  --accent-press:    #C0492E;
-  --accent-ink:      #1A1208;    /* near-black text on terracotta fills */
-  --accent-dim:      rgba(232, 106, 78, 0.14);
+  --accent:       #5b8cff;          /* cobalt — brighter for dark */
+  --accent-ink:   #0c0c0e;
+  --accent-soft:  rgba(91, 140, 255, 0.14);
+  --accent-hover: #7ba2ff;
 
-  /* ---------- SEMANTIC ---------- */
-  --live:       #33FF66;
-  --warn:       #F5A524;
-  --danger:     #FF5A5A;
+  --pos:   #7ad28a;
+  --warn:  #e9b961;
+  --neg:   #e8775a;
+
+  --selection:  rgba(91, 140, 255, 0.30);
+
+  /* ---------- back-compat aliases (legacy class names) ---------- */
+  --bg:         var(--paper);
+  --bg-raise:   var(--bone);
+  --bg-sink:    var(--sub);
+  --fg:         var(--ink);
+  --fg-muted:   var(--dim);
+  --fg-dim:     var(--mute);
+  --fg-faint:   rgba(245, 240, 230, 0.20);
+  --line:        var(--rule);
+  --line-strong: var(--strong-rule);
+  --line-soft:   var(--soft-rule);
+  --accent-press: #2c4ec2;
+  --accent-dim:   var(--accent-soft);
+  --live:       var(--pos);
+  --danger:     var(--neg);
 
   /* ---------- SPACING (4px baseline) ---------- */
-  --sp-0:   0;
-  --sp-1:   4px;
-  --sp-2:   8px;
-  --sp-3:   12px;
-  --sp-4:   16px;
-  --sp-5:   24px;
-  --sp-6:   32px;
-  --sp-7:   48px;
-  --sp-8:   64px;
-  --sp-9:   96px;
-  --sp-10:  128px;
+  --sp-0: 0;
+  --sp-1: 4px;
+  --sp-2: 8px;
+  --sp-3: 12px;
+  --sp-4: 16px;
+  --sp-5: 24px;
+  --sp-6: 32px;
+  --sp-7: 48px;
+  --sp-8: 64px;
+  --sp-9: 96px;
 
   /* ---------- RADII ---------- */
   --r-0: 0;
@@ -114,9 +102,8 @@
   /* ---------- LAYOUT ---------- */
   --col-prose:     72ch;
   --col-code:      88ch;
-  --grid-max:      1100px;  /* Direction A narrows the shell for editorial feel */
-  --grid-gutter:   16px;
-  --grid-cols:     12;
+  --grid-max:      1280px;
+  --grid-pad:      32px;
 
   /* ---------- MOTION ---------- */
   --ease-out:    cubic-bezier(0.22, 1, 0.36, 1);
@@ -126,107 +113,122 @@
   --dur-base:    200ms;
   --dur-slow:    320ms;
 
-  --shadow-pop:  0 8px 32px rgba(0,0,0,0.55), 0 0 0 1px var(--line);
-
-  /* candlelit backdrop — terracotta glow TR, cream glow BL */
-  --bg-candlelight:
-    radial-gradient(1100px 500px at 90% -10%, rgba(232,106,78,0.10), transparent 60%),
-    radial-gradient(900px 420px at -5% 110%, rgba(237,227,206,0.04), transparent 60%);
+  --shadow-pop:  0 8px 32px rgba(0,0,0,0.55), 0 0 0 1px var(--rule);
 }
 
-/* ============= LIGHT MODE — warm paper ============= */
+/* ============= LIGHT MODE — bone paper, deep cobalt ============= */
 :root[data-theme='light'] {
-  --bg:         #F6F1E7;
-  --bg-raise:   #EFE8D8;
-  --bg-sink:    #E9E2CF;
-  --fg:         #1A1410;
-  --fg-muted:   #6B5F52;
-  --fg-dim:     #9E8F7C;
-  --fg-faint:   #C4B9A8;
+  --paper:  #f4f0e6;
+  --bone:   #ebe6d8;
+  --sub:    #e2dccb;
 
-  --line:        rgba(26,20,16,0.18);
-  --line-strong: rgba(26,20,16,0.30);
-  --line-soft:   rgba(26,20,16,0.08);
+  --rule:        rgba(20, 18, 14, 0.14);
+  --soft-rule:   rgba(20, 18, 14, 0.07);
+  --strong-rule: rgba(20, 18, 14, 0.24);
 
-  --selection:  rgba(192, 73, 46, 0.35);
+  --ink:    #14120e;
+  --dim:    rgba(20, 18, 14, 0.62);
+  --mute:   rgba(20, 18, 14, 0.38);
 
-  --accent:          #C0492E;    /* darker terracotta for light-mode contrast */
-  --accent-hover:    #D65E43;
-  --accent-press:    #8C3320;
-  --accent-ink:      #FFF6ED;
-  --accent-dim:      rgba(192, 73, 46, 0.12);
+  --accent:       #2c4ec2;          /* cobalt — desaturated for bone */
+  --accent-ink:   #f4f0e6;
+  --accent-soft:  rgba(44, 78, 194, 0.10);
+  --accent-hover: #4566d6;
 
-  --shadow-pop: 0 8px 32px rgba(26,20,16,0.12), 0 0 0 1px var(--line);
+  --pos:   #3a7a47;
+  --warn:  #9a6b14;
+  --neg:   #a83a1f;
 
-  --bg-candlelight:
-    radial-gradient(1100px 500px at 90% -10%, rgba(192,73,46,0.06), transparent 60%),
-    radial-gradient(900px 420px at -5% 110%, rgba(26,20,16,0.03), transparent 60%);
+  --selection:  rgba(44, 78, 194, 0.22);
+  --shadow-pop: 0 8px 32px rgba(20,18,14,0.10), 0 0 0 1px var(--rule);
+  --accent-press: #1c3a99;
+  --fg-faint:   rgba(20, 18, 14, 0.20);
 }
 
-/* ============= SEMANTIC ELEMENT STYLES ============= */
+/* ============= THEME META ============= */
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme]) {
+    --paper:  #f4f0e6;
+    --bone:   #ebe6d8;
+    --sub:    #e2dccb;
+    --rule:        rgba(20, 18, 14, 0.14);
+    --soft-rule:   rgba(20, 18, 14, 0.07);
+    --strong-rule: rgba(20, 18, 14, 0.24);
+    --ink:    #14120e;
+    --dim:    rgba(20, 18, 14, 0.62);
+    --mute:   rgba(20, 18, 14, 0.38);
+    --accent:       #2c4ec2;
+    --accent-ink:   #f4f0e6;
+    --accent-soft:  rgba(44, 78, 194, 0.10);
+    --accent-hover: #4566d6;
+    --pos:   #3a7a47;
+    --warn:  #9a6b14;
+    --neg:   #a83a1f;
+    --selection:  rgba(44, 78, 194, 0.22);
+  }
+}
 
+/* ============= ELEMENT DEFAULTS ============= */
 html, body {
-  background: var(--bg);
-  background-image: var(--bg-candlelight);
-  background-attachment: fixed;
-  color: var(--fg);
+  background: var(--paper);
+  color: var(--ink);
   font-family: var(--font-body);
-  font-size: var(--fs-base);
+  font-size: var(--fs-body);
   line-height: var(--lh-base);
   font-weight: var(--fw-regular);
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
 
-::selection { background: var(--selection); color: var(--fg); }
+::selection { background: var(--selection); color: var(--ink); }
 
 h1, .h1 {
   font-family: var(--font-display);
-  font-size: var(--fs-5xl);
-  line-height: var(--lh-5xl);
+  font-size: var(--fs-h1);
+  line-height: var(--lh-tight);
   font-weight: var(--fw-regular);
   letter-spacing: var(--tr-tight);
   text-wrap: balance;
   margin: 0;
+  font-feature-settings: 'ss01', 'ss02';
 }
 h2, .h2 {
   font-family: var(--font-display);
-  font-size: var(--fs-3xl);
-  line-height: var(--lh-3xl);
+  font-size: var(--fs-h2);
+  line-height: 1.05;
   font-weight: var(--fw-regular);
-  letter-spacing: var(--tr-tight);
+  letter-spacing: -0.02em;
   text-wrap: balance;
   margin: 0;
 }
 h3, .h3 {
   font-family: var(--font-display);
-  font-size: var(--fs-xl);
-  line-height: var(--lh-xl);
+  font-size: var(--fs-h3);
+  line-height: var(--lh-snug);
   font-weight: var(--fw-regular);
-  letter-spacing: -0.01em;
+  letter-spacing: var(--tr-snug);
   margin: 0;
 }
 h4, .h4 {
   font-family: var(--font-display);
-  font-size: var(--fs-md);
-  line-height: var(--lh-md);
+  font-size: 20px;
+  line-height: 1.2;
   font-weight: var(--fw-regular);
   margin: 0;
 }
 
 p, .p {
   font-family: var(--font-body);
-  font-size: var(--fs-base);
+  font-size: var(--fs-body);
   line-height: var(--lh-base);
-  max-width: var(--col-prose);
   text-wrap: pretty;
   margin: 0;
 }
 
 small, .small {
-  font-size: var(--fs-sm);
-  line-height: var(--lh-sm);
-  color: var(--fg-muted);
+  font-size: var(--fs-small);
+  line-height: 1.5;
+  color: var(--dim);
 }
 
 .label, kbd, code, pre, time, .mono {
@@ -235,51 +237,50 @@ small, .small {
 }
 
 .label {
-  font-size: var(--fs-xs);
-  line-height: var(--lh-xs);
+  font-family: var(--font-mono);
+  font-size: var(--fs-meta);
   letter-spacing: var(--tr-wide);
   text-transform: lowercase;
-  color: var(--fg-muted);
+  color: var(--mute);
 }
 
 .kicker {
   font-family: var(--font-mono);
-  font-size: var(--fs-xs);
+  font-size: var(--fs-meta);
   letter-spacing: var(--tr-widest);
-  text-transform: uppercase;
-  color: var(--fg-dim);
+  text-transform: lowercase;
+  color: var(--mute);
 }
 
 code {
   font-size: 0.92em;
-  background: var(--bg-sink);
+  background: var(--sub);
   padding: 1px 6px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--rule);
   border-radius: var(--r-1);
-  color: var(--fg);
+  color: var(--ink);
 }
 
 pre {
-  font-size: var(--fs-sm);
-  line-height: var(--lh-md);
-  background: var(--bg-sink);
-  border: 1px solid var(--line);
+  font-size: var(--fs-small);
+  line-height: 1.65;
+  background: var(--sub);
+  border: 1px solid var(--rule);
   padding: var(--sp-4);
   overflow-x: auto;
   max-width: var(--col-code);
-  color: var(--fg);
+  color: var(--ink);
 }
-
 pre code { background: transparent; border: 0; padding: 0; }
 
 kbd {
-  font-size: var(--fs-xs);
-  padding: 2px 6px;
-  border: 1px solid var(--line-strong);
-  border-bottom-width: 2px;
+  font-family: var(--font-mono);
+  font-size: var(--fs-micro);
+  padding: 1px 5px;
+  border: 1px solid var(--rule);
   border-radius: var(--r-1);
-  background: var(--bg-raise);
-  color: var(--fg);
+  background: var(--sub);
+  color: var(--ink);
 }
 
 a {
@@ -289,8 +290,7 @@ a {
   text-decoration-thickness: 1px;
   transition: color var(--dur-fast) var(--ease-out);
 }
-a:hover { color: var(--accent-hover); text-decoration: underline; }
-a:active { color: var(--accent-press); }
+a:hover { color: var(--accent-hover); }
 
 :focus { outline: none; }
 :focus-visible {
@@ -301,24 +301,19 @@ a:active { color: var(--accent-press); }
 
 hr {
   border: 0;
-  border-top: 1px solid var(--line);
+  border-top: 1px solid var(--rule);
   margin: var(--sp-6) 0;
 }
 
-input, textarea, select, button {
-  font: inherit;
-  color: inherit;
-}
-
-input[type='text'], input[type='email'], input[type='search'], textarea {
-  background: var(--bg-raise);
-  border: 1px solid var(--line);
+input, textarea, select, button { font: inherit; color: inherit; }
+input[type='text'], input[type='email'], input[type='search'], input[type='password'], textarea {
+  background: var(--paper);
+  border: 1px solid var(--rule);
   border-radius: var(--r-1);
   padding: var(--sp-2) var(--sp-3);
   transition: border-color var(--dur-fast) var(--ease-out);
 }
 input:focus, textarea:focus { border-color: var(--accent); }
-
 button { cursor: pointer; }
 
 @media (prefers-reduced-motion: reduce) {

--- a/work.html
+++ b/work.html
@@ -3,18 +3,17 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="raghav ahuja — work. Three projects shipped end-to-end.">
-  <meta name="theme-color" content="#15110D">
+  <meta name="description" content="raghav ahuja — work. Five studies, thirteen years of shipping things.">
+  <meta name="theme-color" content="#0c0c0e">
   <title>work · raghav ahuja</title>
-      <link rel="preload" href="fonts/InstrumentSerif-Regular.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="fonts/InstrumentSerif-Italic.woff2" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="fonts/JetBrainsMono.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="site.css">
   <link rel="canonical" href="https://raghavahuja.com/work">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://raghavahuja.com/work">
   <meta property="og:title" content="work · raghav ahuja">
-  <meta property="og:description" content="Case studies from 13 years shipping — Arqo, Futbolis.live, EF Education First, Zulily, The Social Booth.">
+  <meta property="og:description" content="Five studies. Thirteen years of shipping things.">
   <meta property="og:image" content="https://raghavahuja.com/og.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
@@ -23,9 +22,9 @@
   <meta name="twitter:site" content="@ahujatries">
   <meta name="twitter:creator" content="@ahujatries">
   <meta name="twitter:title" content="work · raghav ahuja">
-  <meta name="twitter:description" content="Case studies from 13 years shipping — Arqo, Futbolis.live, EF Education First, Zulily, The Social Booth.">
+  <meta name="twitter:description" content="Five studies. Thirteen years of shipping things.">
   <meta name="twitter:image" content="https://raghavahuja.com/og.png">
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%22.9em%22 font-size=%2290%22 fill=%22%230070F3%22%3E_%3C/text%3E%3C/svg%3E">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ctext y=%22.92em%22 font-size=%2290%22 fill=%22%235b8cff%22%3E_%3C/text%3E%3C/svg%3E">
 </head>
 <body data-page="work">
   <script>try { var s = localStorage.getItem('theme'); if (s) document.documentElement.setAttribute('data-theme', s); } catch (e) {}</script>
@@ -36,62 +35,155 @@
     <div id="nav-mount"></div>
 
     <main id="main">
+      <div class="folio-strip">folio 02 — the index · all studies, in order</div>
 
-<section style="padding: 72px 0 40px;">
-      <div class="kicker">folio 02 — the work</div>
-      <h1 style="margin-top: 28px; margin-bottom: 32px; max-width: 14ch;">
-        <span class="em-serif">Work.</span>
-      </h1>
-      <p class="sub" style="font-family: var(--font-display); font-size: 20px; line-height: 1.55; color: var(--fg-muted); max-width: 60ch; margin-bottom: 12px;">
-        Three case studies. One studio. Thirteen years of shipping.
-      </p>
-      <p class="sub" style="font-family: var(--font-display); font-size: 18px; line-height: 1.6; color: var(--fg-muted); max-width: 60ch; margin-bottom: 8px;">
-        Each one is end-to-end — research, system, front-end, back-end, and the decisions that don't make it into tickets. The first is a consumer product. The second is the studio behind it. The third is a decade of enterprise work at a global EdTech platform.
-      </p>
-      <p style="font-family: var(--font-mono); font-size: 11px; color: var(--fg-dim); letter-spacing: 0.08em; text-transform: uppercase; margin-top: 24px;">
-        index → <a href="lab.html" style="color: var(--accent);">/lab</a> · for smaller things
-      </p>
-    </section>
+      <section class="work-page-head">
+        <h1>
+          Five studies.<br>
+          <span class="italic" style="color: var(--dim);">thirteen years of</span><br>
+          <span class="em-accent">shipping things.</span>
+        </h1>
+        <p class="lead">
+          The list is short on purpose. Each entry shipped, ran in production, or moved a metric I can name.
+          Two are open and detailed. One is gated — credentials by request.
+        </p>
+      </section>
 
-    <section class="section">
-      <a href="case-study.html?slug=arqo" class="work-row">
-        <span class="n">01</span>
-        <div>
-          <h3>Arqo</h3>
-          <p class="sub">A mobile-first, script-led filmmaking tool. Shipped solo in 9 days after work, in an agentic-dev workflow with Claude Code.</p>
-        </div>
-        <div class="meta">
-          <div>2026 · 9-day MVP · ongoing</div>
-          <div>sole design engineer</div>
-        </div>
-        <div class="year">read →</div>
-      </a>
-      <a href="case-study.html?slug=jmnpr-labs" class="work-row">
-        <span class="n">02</span>
-        <div>
-          <h3>JMNPR Labs</h3>
-          <p class="sub">A one-person studio shipping production-grade tools for creators, indie filmmakers, and design engineers. Single brand, many verticals. Self-serve, no enterprise deals.</p>
-        </div>
-        <div class="meta">
-          <div>2026 · founder · ongoing</div>
-          <div>founder · design engineer</div>
-        </div>
-        <div class="year">read →</div>
-      </a>
-      <a href="case-study.html?slug=ef" class="work-row">
-        <span class="n">03</span>
-        <div>
-          <h3>EF Education First <span class="locked-chip">🔒 gated</span></h3>
-          <p class="sub">Insurance, checkout, quoting across 50+ countries — and an in-house design system tool supporting three brands. The case study is gated; email for access.</p>
-        </div>
-        <div class="meta">
-          <div>2022 — present</div>
-          <div>senior product designer</div>
-        </div>
-        <div class="year">request access →</div>
-      </a>
-    </section>
+      <div class="work-list" style="margin-top: 16px;">
+        <a href="case-study.html?slug=arqo" class="case-row">
+          <span class="n">01</span>
+          <div>
+            <div class="case-title-row">
+              <h3>Arqo</h3>
+              <span class="open-chip">● open</span>
+            </div>
+            <div class="sub">Mobile-first screenwriting, shipped solo in nine days.</div>
+            <div class="meta">sole design engineer · 2026 — ongoing</div>
+          </div>
+          <div>
+            <div class="col-label">surfaces</div>
+            <div class="pills">
+              <span class="pill">editor</span>
+              <span class="pill">paginator</span>
+              <span class="pill">voice ai</span>
+              <span class="pill">collab</span>
+            </div>
+          </div>
+          <div>
+            <div class="col-label">stack</div>
+            <div class="stack">react native, pgvector, supabase, crdt, expo</div>
+          </div>
+          <div class="read">read →</div>
+        </a>
 
+        <a href="case-study.html?slug=jmnpr-labs" class="case-row">
+          <span class="n">02</span>
+          <div>
+            <div class="case-title-row">
+              <h3>JMNPR Labs</h3>
+              <span class="open-chip">● open</span>
+            </div>
+            <div class="sub">A one-person studio. Story Kit live, five flagships on deck.</div>
+            <div class="meta">founder · design engineer · 2026 — ongoing</div>
+          </div>
+          <div>
+            <div class="col-label">surfaces</div>
+            <div class="pills">
+              <span class="pill">story kit</span>
+              <span class="pill">fdx tools</span>
+              <span class="pill">storefront</span>
+            </div>
+          </div>
+          <div>
+            <div class="col-label">stack</div>
+            <div class="stack">next.js, react-pdf, fdx, tauri</div>
+          </div>
+          <div class="read">read →</div>
+        </a>
+
+        <a href="case-study.html?slug=ef" class="case-row">
+          <span class="n">03</span>
+          <div>
+            <div class="case-title-row">
+              <h3>EF Education First</h3>
+              <span class="locked-chip">🔒 gated</span>
+            </div>
+            <div class="sub">Insurance, checkout, quoting — three brands, one design system.</div>
+            <div class="meta">senior product designer · 2022 — present</div>
+          </div>
+          <div>
+            <div class="col-label">surfaces</div>
+            <div class="pills">
+              <span class="pill">quoting</span>
+              <span class="pill">checkout</span>
+              <span class="pill">design system</span>
+            </div>
+          </div>
+          <div>
+            <div class="col-label">stack</div>
+            <div class="stack">react, figma, design tokens, a/b</div>
+          </div>
+          <div class="read">read →</div>
+        </a>
+
+        <a href="case-study.html?slug=tessera" class="case-row">
+          <span class="n">04</span>
+          <div>
+            <div class="case-title-row">
+              <h3>Tessera</h3>
+            </div>
+            <div class="sub">Internal design tool. Tokens, themes, three brands.</div>
+            <div class="meta">design engineer · ef internal · 2023 — 2024</div>
+          </div>
+          <div>
+            <div class="col-label">surfaces</div>
+            <div class="pills">
+              <span class="pill">token pipeline</span>
+              <span class="pill">preview app</span>
+            </div>
+          </div>
+          <div>
+            <div class="col-label">stack</div>
+            <div class="stack">typescript, style-dictionary, figma api</div>
+          </div>
+          <div class="read">read →</div>
+        </a>
+
+        <a href="case-study.html?slug=pre-ef" class="case-row">
+          <span class="n">05</span>
+          <div>
+            <div class="case-title-row">
+              <h3>Selected pre-EF work</h3>
+            </div>
+            <div class="sub">A decade of product, brand, and platform work — agencies &amp; in-house.</div>
+            <div class="meta">designer · then design engineer · 2012 — 2022</div>
+          </div>
+          <div>
+            <div class="col-label">surfaces</div>
+            <div class="pills">
+              <span class="pill">product</span>
+              <span class="pill">brand</span>
+              <span class="pill">platform</span>
+            </div>
+          </div>
+          <div>
+            <div class="col-label">stack</div>
+            <div class="stack">various</div>
+          </div>
+          <div class="read">read →</div>
+        </a>
+      </div>
+
+      <div class="filter-bar">
+        <span>filter ·</span>
+        <span class="filter active">all</span>
+        <span class="filter">shipped</span>
+        <span class="filter">design eng</span>
+        <span class="filter">product</span>
+        <span class="filter">systems</span>
+        <span class="filter">gated</span>
+        <span class="count">5 of 5 visible</span>
+      </div>
     </main>
 
     <div id="footer-mount"></div>


### PR DESCRIPTION
## Summary
- **New design system**: cobalt accent, paper/bone/ink palette, Fraunces × Geist × JetBrains Mono (pulled from Google Fonts CDN)
- **New mark**: \`raghav_\` with blinking caret block (replaces "raghav ahuja.")
- **New chrome**: 3-column masthead (vol. iv · no. 4 · portfolio | raghavahuja.com | jamnapaar/brooklyn clocks), restructured nav with day/night toggle button
- **All pages rebuilt** to match supplied mockups: index, work, about, contact, notes, lab, 404 (full rewrites). docs and case-study get minimal head-section patches; their JS-driven content keeps working against the new tokens.
- **Ship-log replaced** with a curated 4-card highlights rail on home — the live-activity GitHub fetcher in \`site.js\` now no-ops since its mount class is gone.

## Test plan
- [ ] Hard-reload home — fonts load from Google, masthead/nav/footer render via JS chrome injection
- [ ] Toggle day/night via the new \`☾ night\` / \`☀ day\` button (and via \`t\` key)
- [ ] ⌘K command palette still opens, fuzzy-searches, navigates
- [ ] /work, /about, /contact, /notes, /lab, /404 all render with new layouts at 1280px and below
- [ ] /docs and /case-study?slug=arqo still render existing content (just restyled)
- [ ] Mobile (≤560px): hero stacks, highlights collapse to 1-col, lab cards collapse to 1-col
- [ ] EF case-study password gate still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)