### PR TITLE
case-study(arqo): canvas hero figure + 4-col bigstats strip

### DIFF
--- a/case-study.html
+++ b/case-study.html
@@ -52,6 +52,9 @@
           </div>
         </header>
 
+        <figure class="cs-canvas" id="cs-canvas" hidden></figure>
+        <div class="case-bigstats" id="cs-bigstats" hidden></div>
+
         <article class="case-body" id="cs-body"></article>
 
         <nav class="case-nav" id="cs-nav" aria-label="case study nav"></nav>
@@ -1431,6 +1434,86 @@ u.searchParams.set('past_hours', '24');</code></pre>
         `<div class="case-stack-row"><span class="dep">${dep}</span><span class="ver">${ver}</span></div>`
       ).join('');
       stackWrap.hidden = false;
+    }
+
+    // hero figure (canvas) + big-stats strip — per-case, opt-in
+    const HERO = {
+      arqo: {
+        canvas: {
+          file: 'arqo / scripts / scene_04.fountain',
+          stamp: 'saved · 2s ago',
+          script: [
+            ['12', 'scene', 'int. apartment — night'],
+            ['13', 'action', 'Rain on the kitchen window. MAYA, 28, watches her phone light up.'],
+            ['14', 'character', 'MAYA'],
+            ['15', 'dialogue', 'You shot all of this on the train?'],
+            ['16', 'character', 'DEV (V.O.)'],
+            ['17', 'dialogue', 'Between Newark and Trenton. Forty-one minutes.'],
+            ['18', 'action', 'She smiles. Tap. The script becomes a shot list.'],
+          ],
+          phone: {
+            title: 'Scene 04 — Apartment',
+            sub: '7 SHOTS · 4 MIN ESTIMATED',
+          },
+        },
+        bigstats: [
+          ['build velocity', '9', 'days', 'solo · MVP engine to public beta'],
+          ['codebase', '42', 'k', 'lines · TS-only · 0 untyped'],
+          ['platforms', '3', '', 'iOS · Android · Web · one core'],
+          ['closed beta', '1,240', '', 'writers, directors, students'],
+        ],
+      },
+    };
+
+    const hero = HERO[slug];
+    if (hero && hero.canvas) {
+      const cv = hero.canvas;
+      const canvasEl = document.getElementById('cs-canvas');
+      const lines = cv.script.map(([n, kind, text]) =>
+        `<div class="cs-canvas-line"><span class="ln">${n}</span><span class="txt ${kind}">${text}</span></div>`
+      ).join('');
+      canvasEl.innerHTML = `
+        <div class="cs-canvas-head">
+          <div class="dots"><span></span><span></span><span></span></div>
+          <div class="file">${cv.file}</div>
+          <div class="stamp">${cv.stamp}</div>
+        </div>
+        <div class="cs-canvas-body">
+          <div class="cs-canvas-script">${lines}</div>
+          <div class="cs-canvas-phone-wrap">
+            <div class="cs-phone">
+              <div class="cs-phone-head"><span>9:41</span><span>● ● ●</span></div>
+              <div class="cs-phone-title">${cv.phone.title}</div>
+              <div class="cs-phone-sub">${cv.phone.sub}</div>
+              <div class="cs-phone-stack">
+                <div class="cs-phone-line m"></div>
+                <div class="cs-phone-line s"></div>
+                <div class="cs-phone-line accent"></div>
+                <div class="cs-phone-line m"></div>
+                <div class="cs-phone-line s"></div>
+                <div class="cs-phone-line m"></div>
+              </div>
+              <div class="cs-phone-foot">
+                <div class="chip"></div>
+                <div class="chip on"></div>
+                <div class="chip"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      `;
+      canvasEl.hidden = false;
+    }
+    if (hero && hero.bigstats) {
+      const statsEl = document.getElementById('cs-bigstats');
+      statsEl.innerHTML = hero.bigstats.map(([label, num, unit, sub]) =>
+        `<div class="bigstat">
+          <div class="k">${label}</div>
+          <div class="n">${num}${unit ? `<em>${unit}</em>` : ''}</div>
+          <div class="s">${sub}</div>
+        </div>`
+      ).join('');
+      statsEl.hidden = false;
     }
 
     // body — clone the template

--- a/site.css
+++ b/site.css
@@ -718,6 +718,181 @@ body { margin: 0; min-height: 100vh; background: var(--paper); color: var(--ink)
 .case-stack-row { display: grid; grid-template-columns: 1fr auto; padding: 6px 0; border-bottom: 1px dashed var(--soft-rule); color: var(--ink); }
 .case-stack-row .ver { color: var(--accent); }
 
+/* ====================================================
+   CASE — hero canvas figure (script + phone mockup)
+   ==================================================== */
+.cs-canvas {
+  margin: 32px 0 0;
+  border: 1px solid var(--rule);
+  background:
+    linear-gradient(180deg, var(--accent-soft), transparent 40%),
+    var(--bone);
+  overflow: hidden;
+  position: relative;
+}
+.cs-canvas-head {
+  display: flex; align-items: center; gap: 14px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--rule);
+  font-family: var(--font-mono); font-size: var(--fs-meta);
+  color: var(--mute); letter-spacing: 0.04em;
+}
+.cs-canvas-head .dots { display: flex; gap: 6px; }
+.cs-canvas-head .dots span {
+  width: 9px; height: 9px; border-radius: 50%;
+  background: var(--strong-rule);
+}
+.cs-canvas-head .file { color: var(--dim); }
+.cs-canvas-head .stamp {
+  margin-left: auto; color: var(--mute);
+  font-size: var(--fs-micro); letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.cs-canvas-body {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  min-height: 320px;
+}
+.cs-canvas-script {
+  padding: 28px 32px;
+  border-right: 1px solid var(--rule);
+  display: flex; flex-direction: column; gap: 14px;
+  background:
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0 27px,
+      var(--soft-rule) 27px 28px
+    );
+  font-family: var(--font-mono);
+}
+.cs-canvas-line { display: flex; gap: 14px; align-items: baseline; }
+.cs-canvas-line .ln {
+  color: var(--mute);
+  font-size: var(--fs-micro);
+  width: 18px; text-align: right; flex-shrink: 0;
+}
+.cs-canvas-line .txt { font-size: 12px; line-height: 1.5; }
+.cs-canvas-line .scene {
+  color: var(--accent);
+  letter-spacing: 0.1em; text-transform: uppercase;
+  font-size: var(--fs-meta);
+}
+.cs-canvas-line .character {
+  color: var(--ink); padding-left: 80px; letter-spacing: 0.1em;
+}
+.cs-canvas-line .dialogue {
+  padding-left: 60px; padding-right: 60px; color: var(--dim);
+}
+.cs-canvas-line .action { color: var(--dim); }
+
+.cs-canvas-phone-wrap {
+  padding: 28px 32px;
+  background:
+    linear-gradient(180deg, var(--accent-soft), transparent),
+    var(--sub);
+  display: flex; align-items: stretch; justify-content: center;
+}
+.cs-phone {
+  width: 200px;
+  border: 1px solid var(--strong-rule);
+  border-radius: 22px;
+  background: var(--paper);
+  padding: 14px 12px;
+  display: flex; flex-direction: column; gap: 10px;
+  box-shadow: var(--shadow-pop);
+}
+.cs-phone-head {
+  display: flex; justify-content: space-between;
+  font-family: var(--font-mono);
+  color: var(--mute); font-size: 9px;
+}
+.cs-phone-title {
+  color: var(--ink); font-size: 11px;
+  font-family: var(--font-mono); margin-bottom: 2px;
+}
+.cs-phone-sub {
+  color: var(--mute); font-size: 9px;
+  font-family: var(--font-mono);
+  letter-spacing: 0.06em; margin-bottom: 6px;
+}
+.cs-phone-stack { display: flex; flex-direction: column; gap: 5px; margin-top: 4px; }
+.cs-phone-line { height: 6px; border-radius: 2px; background: var(--rule); }
+.cs-phone-line.s { width: 60%; }
+.cs-phone-line.m { width: 85%; }
+.cs-phone-line.accent { background: var(--accent); width: 40%; opacity: 0.78; }
+.cs-phone-foot { margin-top: auto; display: flex; gap: 6px; padding-top: 10px; }
+.cs-phone-foot .chip {
+  flex: 1; height: 20px; border-radius: 4px;
+  background: var(--rule); border: 1px solid var(--strong-rule);
+}
+.cs-phone-foot .chip.on {
+  background: var(--accent-soft); border-color: var(--accent);
+}
+
+@media (max-width: 720px) {
+  .cs-canvas-body { grid-template-columns: 1fr; }
+  .cs-canvas-script { border-right: none; border-bottom: 1px solid var(--rule); }
+  .cs-canvas-line .character { padding-left: 24px; }
+  .cs-canvas-line .dialogue { padding-left: 24px; padding-right: 24px; }
+}
+
+/* ====================================================
+   CASE — big stats strip (4-col bordered horizontal)
+   ==================================================== */
+.case-bigstats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  margin: 32px 0 0;
+  border: 1px solid var(--rule);
+  border-radius: 0;
+}
+.case-bigstats .bigstat {
+  padding: 22px 22px;
+  border-right: 1px solid var(--rule);
+  min-width: 0;
+}
+.case-bigstats .bigstat:last-child { border-right: 0; }
+.case-bigstats .bigstat .k {
+  font-family: var(--font-mono);
+  font-size: var(--fs-micro);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--mute);
+  margin-bottom: 10px;
+}
+.case-bigstats .bigstat .n {
+  font-family: var(--font-display);
+  font-size: 40px; line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  font-feature-settings: 'tnum' 1;
+}
+.case-bigstats .bigstat .n em {
+  color: var(--accent);
+  font-style: normal;
+  font-size: 0.5em;
+  margin-left: 2px;
+  letter-spacing: 0;
+}
+.case-bigstats .bigstat .s {
+  font-family: var(--font-mono);
+  font-size: var(--fs-micro);
+  color: var(--dim);
+  margin-top: 8px;
+  line-height: 1.5;
+}
+@media (max-width: 880px) {
+  .case-bigstats { grid-template-columns: repeat(2, 1fr); }
+  .case-bigstats .bigstat { border-right: 0; border-top: 1px solid var(--rule); }
+  .case-bigstats .bigstat:nth-child(odd) { border-right: 1px solid var(--rule); }
+  .case-bigstats .bigstat:nth-child(-n+2) { border-top: 0; }
+}
+@media (max-width: 480px) {
+  .case-bigstats { grid-template-columns: 1fr; }
+  .case-bigstats .bigstat { border-right: 0; border-top: 1px solid var(--rule); }
+  .case-bigstats .bigstat:first-child { border-top: 0; }
+}
+
 .case-stat-row {
   display: grid; grid-template-columns: repeat(3, 1fr);
   gap: 32px; padding: 36px 0;


### PR DESCRIPTION
## Summary
Brings the Arqo marketing-page assets onto the case study page and arranges the layout to match the design handoff.

- **Canvas hero figure** between case header and prose: file-titled card with three dots, a faux script editor on the left (line numbers + scene/character/dialogue/action coloring) and a phone mockup on the right with a faded accent shot-list bar.
- **4-column bigstats strip** under the canvas: `build velocity` / `codebase` / `platforms` / `closed beta`, bordered horizontal, accent unit suffixes (`9 days`, `42k`).
- Both render only when a slug has a `HERO` entry — Arqo is the only one populated, so other cases (`aleida`, `jmnpr-labs`, `ef`, `zulily`, …) are untouched.

## How it's wired
- `case-study.html`: two new hidden mount slots (`#cs-canvas`, `#cs-bigstats`) between `</header>` and `<article class="case-body">`. The existing per-slug renderer now also reads a `HERO` table and fills + unhides them.
- `site.css`: new `.cs-canvas*` and `.case-bigstats` blocks built on the existing tokens (`--paper`, `--bone`, `--rule`, `--accent`, `--accent-soft`, etc.) so light/dark themes both render correctly. Mobile collapses canvas to one column and bigstats from 4 → 2 → 1.

## Test plan
- [ ] `/case-study?slug=arqo` shows canvas + bigstats above the prose, and the existing case-stack receipts and 3-stat row still render below.
- [ ] `/case-study?slug=aleida` (and other slugs) are visually unchanged — slots stay hidden.
- [ ] Light + dark theme both look correct (canvas bg, phone shadow, accent line).
- [ ] Mobile: canvas stacks vertically, bigstats becomes 2-col then 1-col.

🤖 Generated with [Claude Code](https://claude.com/claude-code)