### PR TITLE
Fix ⌘K, group mobile mockups, add desktop arqo screens

### DIFF
--- a/site.js
+++ b/site.js
@@ -160,55 +160,92 @@
   ];
   const groupLabels = { go: 'NAVIGATE', mail: 'EMAIL', social: 'SOCIAL', file: 'FILES', sys: 'SYSTEM' };
 
+  function isExt(it){ return it && (it.kind === 'mail' || it.kind === 'social' || it.kind === 'file'); }
   function filtered(){
-    const q = cmdkQ.toLowerCase();
+    const q = cmdkQ.toLowerCase().trim();
     return ITEMS.filter(i => !q || i.label.toLowerCase().includes(q) || i.hint.toLowerCase().includes(q));
   }
-  function renderCmdk(){
+
+  // Build the palette chrome once. Input listener attaches once, so caret/IME state survives every list re-render.
+  function mountCmdk(){
     const el = document.getElementById('cmdk-overlay');
     if (!el) return;
-    const items = filtered();
-    if (cmdkSel >= items.length) cmdkSel = Math.max(0, items.length-1);
-    const groups = {};
-    items.forEach(it => { (groups[it.kind] = groups[it.kind] || []).push(it); });
-    let idx = -1;
-    const inner = `
+    el.innerHTML = `
       <div class="cmdk-pal" onclick="event.stopPropagation()">
         <div class="cmdk-input">
           <span style="color:var(--heat);font-size:14px;font-weight:600">›</span>
-          <input id="cmdk-q" placeholder="type a thing — work · arqo · email · resume · tweaks" value="${cmdkQ.replace(/"/g,'&quot;')}"/>
+          <input id="cmdk-q" placeholder="type a thing — work · arqo · email · resume · tweaks" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"/>
           <span class="cmdk-esc">ESC</span>
         </div>
-        <div class="cmdk-list">
-          ${items.length === 0 ? '<div style="padding:24px 20px;color:var(--fg-dim);font-size:13px;font-style:italic">nothing matches. that is the honest answer.</div>' : ''}
-          ${Object.keys(groups).map(k => `
-            <div class="cmdk-group">${groupLabels[k] || k.toUpperCase()}</div>
-            ${groups[k].map(it => { idx++; const sel = idx === cmdkSel; const ext = (it.kind === 'mail' || it.kind === 'social' || it.kind === 'file'); return `
-              <a class="cmdk-row${sel?' sel':''}" data-idx="${idx}" href="${it.href || '#'}" data-action="${it.action || ''}"${ext ? ' target="_blank" rel="noopener"' : ''}>
-                <span>${it.label}</span><span class="cmdk-hint">${it.hint}</span>
-              </a>
-            `;}).join('')}
-          `).join('')}
-        </div>
-        <div class="cmdk-foot"><span>↑↓ NAVIGATE · ↵ SELECT</span><span>${items.length} ITEMS</span></div>
+        <div class="cmdk-list" id="cmdk-list"></div>
+        <div class="cmdk-foot" id="cmdk-foot"></div>
       </div>`;
-    el.innerHTML = inner;
     const inp = document.getElementById('cmdk-q');
-    if (inp) {
-      inp.focus();
-      inp.addEventListener('input', (e) => { cmdkQ = e.target.value; cmdkSel = 0; renderCmdk(); });
-    }
-    el.querySelectorAll('.cmdk-row').forEach(row => {
-      row.addEventListener('mouseenter', () => { cmdkSel = +row.dataset.idx; renderCmdk(); });
+    inp.value = cmdkQ;
+    inp.focus();
+    // Caret to end so re-opens feel natural.
+    try { inp.setSelectionRange(cmdkQ.length, cmdkQ.length); } catch (_) {}
+    inp.addEventListener('input', () => {
+      cmdkQ = inp.value;
+      cmdkSel = 0;
+      renderList();
+    });
+    renderList();
+  }
+
+  function renderList(){
+    const list = document.getElementById('cmdk-list');
+    const foot = document.getElementById('cmdk-foot');
+    if (!list) return;
+    const items = filtered();
+    if (cmdkSel >= items.length) cmdkSel = Math.max(0, items.length - 1);
+    const groups = {};
+    items.forEach(it => { (groups[it.kind] = groups[it.kind] || []).push(it); });
+    let idx = -1;
+    list.innerHTML = items.length === 0
+      ? '<div style="padding:24px 20px;color:var(--fg-dim);font-size:13px;font-style:italic">nothing matches. that is the honest answer.</div>'
+      : Object.keys(groups).map(k => `
+          <div class="cmdk-group">${groupLabels[k] || k.toUpperCase()}</div>
+          ${groups[k].map(it => { idx++; const sel = idx === cmdkSel; const ext = isExt(it); return `
+            <a class="cmdk-row${sel?' sel':''}" data-idx="${idx}" href="${it.href || '#'}" data-action="${it.action || ''}"${ext ? ' target="_blank" rel="noopener"' : ''}>
+              <span>${it.label}</span><span class="cmdk-hint">${it.hint}</span>
+            </a>
+          `;}).join('')}
+        `).join('');
+    foot.innerHTML = `<span>↑↓ NAVIGATE · ↵ SELECT · ESC CLOSE</span><span>${items.length} ITEM${items.length===1?'':'S'}</span>`;
+    const rows = list.querySelectorAll('.cmdk-row');
+    rows.forEach(row => {
+      // Hover only toggles .sel — no DOM rebuild, no focus loss while typing.
+      row.addEventListener('mouseenter', () => {
+        const next = +row.dataset.idx;
+        if (next === cmdkSel) return;
+        cmdkSel = next;
+        rows.forEach(r => r.classList.toggle('sel', +r.dataset.idx === cmdkSel));
+      });
       row.addEventListener('click', (e) => {
-        const idx = +row.dataset.idx;
-        const it = items[idx];
+        const it = filtered()[+row.dataset.idx];
+        if (!it) { e.preventDefault(); return; }
         if (it.action === 'tweaks') { e.preventDefault(); closeCmdk(); openTweaks(); return; }
-        if (it.action === 'theme')  { e.preventDefault(); /* no-op, doctrine */ closeCmdk(); return; }
-        if (!it.href || it.href === '#') e.preventDefault();
+        if (it.action === 'theme')  { e.preventDefault(); closeCmdk(); return; }
+        if (!it.href || it.href === '#') { e.preventDefault(); return; }
+        // External (target=_blank) opens a new tab — close the overlay so the current page is usable.
+        // Internal — default <a> handles navigation; close so the overlay doesn't briefly persist.
+        closeCmdk();
       });
     });
   }
+
+  function moveSel(delta){
+    const items = filtered();
+    if (!items.length) return;
+    cmdkSel = Math.max(0, Math.min(items.length - 1, cmdkSel + delta));
+    const list = document.getElementById('cmdk-list');
+    if (!list) return;
+    list.querySelectorAll('.cmdk-row').forEach(r => r.classList.toggle('sel', +r.dataset.idx === cmdkSel));
+    const sel = list.querySelector('.cmdk-row.sel');
+    if (sel && sel.scrollIntoView) sel.scrollIntoView({ block: 'nearest' });
+  }
+
   function openCmdk(){
     if (cmdkOpen) return;
     cmdkOpen = true; cmdkQ = ''; cmdkSel = 0;
@@ -216,7 +253,7 @@
     el.id = 'cmdk-overlay';
     document.body.appendChild(el);
     el.addEventListener('click', closeCmdk);
-    renderCmdk();
+    mountCmdk();
   }
   function closeCmdk(){
     cmdkOpen = false;
@@ -225,26 +262,26 @@
   }
   window.addEventListener('open-cmdk', openCmdk);
   window.addEventListener('keydown', (e) => {
-    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') { e.preventDefault(); cmdkOpen ? closeCmdk() : openCmdk(); }
-    else if (e.key === 'Escape' && cmdkOpen) closeCmdk();
-    else if (cmdkOpen && (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Enter')) {
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
       e.preventDefault();
-      const items = filtered();
-      if (e.key === 'ArrowDown') cmdkSel = Math.min(items.length-1, cmdkSel+1);
-      if (e.key === 'ArrowUp')   cmdkSel = Math.max(0, cmdkSel-1);
-      if (e.key === 'Enter')     {
-        const it = items[cmdkSel];
-        if (!it) return;
-        if (it.action === 'tweaks') { closeCmdk(); openTweaks(); return; }
-        if (it.action === 'theme')  { closeCmdk(); return; }
-        if (it.href) {
-          const ext = (it.kind === 'mail' || it.kind === 'social' || it.kind === 'file');
-          if (ext) window.open(it.href, '_blank', 'noopener');
-          else location.href = it.href;
-          closeCmdk();
-        }
+      cmdkOpen ? closeCmdk() : openCmdk();
+      return;
+    }
+    if (!cmdkOpen) return;
+    if (e.key === 'Escape')    { e.preventDefault(); closeCmdk(); return; }
+    if (e.key === 'ArrowDown') { e.preventDefault(); moveSel(1);  return; }
+    if (e.key === 'ArrowUp')   { e.preventDefault(); moveSel(-1); return; }
+    if (e.key === 'Enter')     {
+      e.preventDefault();
+      const it = filtered()[cmdkSel];
+      if (!it) return;
+      if (it.action === 'tweaks') { closeCmdk(); openTweaks(); return; }
+      if (it.action === 'theme')  { closeCmdk(); return; }
+      if (it.href && it.href !== '#') {
+        if (isExt(it)) window.open(it.href, '_blank', 'noopener');
+        else location.href = it.href;
+        closeCmdk();
       }
-      renderCmdk();
     }
   });
 })();

--- a/work/arqo.html
+++ b/work/arqo.html
@@ -607,6 +607,514 @@
   background: var(--r-lime); border-radius: 4px;
   padding: 2px 8px; display: inline-block; color: var(--r-bg);
 }
+
+/* ----- PHONES GALLERY (multiple phones in a row) ----- */
+.aq-phones-row {
+  margin: var(--s-5) 0 var(--s-4);
+  display: flex; gap: 22px;
+  justify-content: center;
+  overflow-x: auto;
+  padding: 4px 0 12px;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+}
+.aq-phones-row .aq-phone {
+  width: 320px; flex-shrink: 0;
+  scroll-snap-align: center;
+  border-radius: 32px;
+}
+.aq-phones-row .aq-phone .aq-app { min-height: 600px; border-radius: 24px; }
+.aq-phones-row .aq-phone-tag {
+  text-align: center;
+  font-family: var(--font-mono); font-size: 10px;
+  color: var(--fg-faint); letter-spacing: 0.16em;
+  text-transform: uppercase;
+  margin-top: 10px;
+}
+@media (max-width: 980px) {
+  .aq-phones-row { justify-content: flex-start; padding-left: 16px; }
+}
+
+/* ----- MOBILE EDITOR (Action mode, contenteditable demo) ----- */
+.aq-app.editor-mobile {
+  --m-bg:   #0a0c08;
+  --m-fg:   #e8efd0;
+  --m-dim:  #8a9072;
+  --m-rule: rgba(168,200,140,0.18);
+  --m-lime: #c0e656;
+  --m-paper:#efe8d6;
+  --m-paper-ink:#1a1810;
+  background: var(--m-bg); color: var(--m-fg);
+}
+.aq-app.editor-mobile .me-statusbar {
+  display: grid; grid-template-columns: 30px auto 1fr auto auto auto;
+  gap: 10px; align-items: center;
+  padding: 12px 12px 10px;
+  border-bottom: 1px solid var(--m-rule);
+}
+.aq-app.editor-mobile .me-statusbar .ttl {
+  font-family: var(--font-sans); font-weight: 600; font-size: 14px;
+  display: flex; align-items: center; gap: 4px;
+}
+.aq-app.editor-mobile .me-statusbar .ttl .arrow { color: var(--m-dim); }
+.aq-app.editor-mobile .me-statusbar .saved {
+  font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.14em;
+  border: 1px solid rgba(168,216,96,0.4);
+  color: var(--m-lime);
+  padding: 4px 8px; border-radius: 4px;
+  display: inline-flex; align-items: center; gap: 5px;
+}
+.aq-app.editor-mobile .me-statusbar .saved::before {
+  content: ''; width: 5px; height: 5px; border-radius: 50%; background: var(--m-lime);
+}
+.aq-app.editor-mobile .me-statusbar .meta {
+  font-family: var(--font-mono); font-size: 10px;
+  color: var(--m-dim); letter-spacing: 0.06em;
+}
+.aq-app.editor-mobile .me-statusbar .ic { font-size: 16px; color: var(--m-fg); }
+.aq-app.editor-mobile .me-toolbar {
+  display: flex; gap: 6px; padding: 10px 12px;
+  border-bottom: 1px solid var(--m-rule);
+  overflow-x: auto;
+}
+.aq-app.editor-mobile .me-toolbar .pill {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 7px 12px; border-radius: 4px;
+  border: 1px solid var(--m-rule);
+  color: var(--m-fg); white-space: nowrap;
+}
+.aq-app.editor-mobile .me-toolbar .pill.lime {
+  background: var(--m-lime); color: var(--m-bg); border-color: var(--m-lime);
+}
+.aq-app.editor-mobile .me-toolbar .pill.dim { color: var(--m-dim); }
+.aq-app.editor-mobile .me-script {
+  flex: 1; padding: 16px 12px;
+  font-family: var(--font-mono); font-size: 14px; line-height: 1.5;
+  color: var(--m-fg);
+}
+.aq-app.editor-mobile .me-script .block {
+  display: grid; grid-template-columns: 14px 1fr;
+  gap: 6px; margin-bottom: 14px;
+  align-items: flex-start;
+}
+.aq-app.editor-mobile .me-script .grip {
+  color: var(--m-dim); padding-top: 4px; font-size: 12px;
+}
+.aq-app.editor-mobile .me-script .block.ph .body { color: var(--m-dim); font-style: italic; }
+.aq-app.editor-mobile .me-elements {
+  display: flex; gap: 5px; padding: 10px 10px 8px;
+  background: var(--m-paper); color: var(--m-paper-ink);
+  overflow-x: auto;
+}
+.aq-app.editor-mobile .me-elements .pill {
+  font-family: var(--font-mono); font-size: 10.5px; font-weight: 700;
+  letter-spacing: 0.1em;
+  padding: 9px 12px; border: 1.5px solid var(--m-paper-ink);
+  background: transparent; color: var(--m-paper-ink);
+  white-space: nowrap;
+}
+.aq-app.editor-mobile .me-elements .pill.on {
+  background: var(--m-lime); border-color: var(--m-paper-ink);
+}
+.aq-app.editor-mobile .me-botnav {
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  border-top: 1px solid var(--m-rule);
+  padding: 10px 0 14px;
+}
+.aq-app.editor-mobile .me-botnav .it {
+  text-align: center; color: var(--m-dim);
+  font-family: var(--font-mono); font-size: 9.5px;
+  letter-spacing: 0.08em;
+}
+.aq-app.editor-mobile .me-botnav .it span { font-size: 18px; display: block; margin-bottom: 3px; }
+.aq-app.editor-mobile .me-botnav .it.on { color: var(--m-bg); font-weight: 700; }
+.aq-app.editor-mobile .me-botnav .it.on span {
+  background: var(--m-lime); border-radius: 4px;
+  padding: 2px 8px; display: inline-block; color: var(--m-bg);
+}
+
+/* ===== ARQO DESKTOP MOCKUPS (Project Dashboard, Library, Dashboard + ⌘K) ===== */
+.aq-desk-wrap { margin: var(--s-5) 0 var(--s-4); }
+.aq-desk {
+  --d-bg:   #0a0c08;
+  --d-card: #0f1110;
+  --d-fg:   #e8efd0;
+  --d-dim:  #8a9072;
+  --d-faint:#5b6248;
+  --d-rule: rgba(168,200,140,0.16);
+  --d-lime: #c0e656;
+  --d-paper:#efe8d6;
+  background: var(--d-bg); color: var(--d-fg);
+  font-family: var(--font-mono);
+  border: 1px solid var(--d-rule);
+  border-radius: 8px;
+  display: grid; grid-template-columns: 200px 1fr;
+  min-height: 540px;
+  overflow: hidden;
+  position: relative;
+}
+.aq-desk .d-side {
+  border-right: 1px solid var(--d-rule);
+  padding: 14px 0 16px;
+  display: flex; flex-direction: column; gap: 12px;
+}
+.aq-desk .d-side .wm {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0 14px 14px; border-bottom: 1px solid var(--d-rule);
+  font-family: var(--font-mono); font-weight: 700; font-size: 16px;
+  letter-spacing: -0.04em;
+}
+.aq-desk .d-side .wm .dot { color: var(--d-lime); }
+.aq-desk .d-side .wm .pull {
+  font-family: var(--font-mono); font-size: 11px;
+  border: 1px solid var(--d-rule); padding: 2px 6px;
+  color: var(--d-dim);
+}
+.aq-desk .d-side h6 {
+  margin: 0; padding: 0 14px;
+  font-size: 9.5px; letter-spacing: 0.18em;
+  color: var(--d-faint); font-weight: 600;
+}
+.aq-desk .d-side .nav { display: flex; flex-direction: column; gap: 0; }
+.aq-desk .d-side .item {
+  padding: 10px 14px; display: flex; align-items: center; gap: 10px;
+  font-size: 12px; letter-spacing: 0.06em;
+  color: var(--d-dim); text-transform: uppercase;
+}
+.aq-desk .d-side .item .ic { width: 16px; opacity: 0.8; }
+.aq-desk .d-side .item.on {
+  color: var(--d-bg); background: var(--d-lime); font-weight: 700;
+}
+.aq-desk .d-side .sub { display: flex; flex-direction: column; padding-left: 8px; }
+.aq-desk .d-side .sub .si {
+  padding: 7px 14px 7px 28px; font-size: 11px;
+  color: var(--d-dim); letter-spacing: 0.08em;
+  text-transform: uppercase;
+  display: flex; gap: 8px;
+}
+.aq-desk .d-side .sub .si.on {
+  color: var(--d-fg);
+  border-left: 2px solid var(--d-lime);
+  padding-left: 26px;
+  background: rgba(192,230,86,0.05);
+}
+.aq-desk .d-side .sub .pin {
+  display: flex; justify-content: space-between;
+  padding: 8px 14px; font-size: 11px;
+  color: var(--d-fg); letter-spacing: 0.04em;
+  border: 1px solid var(--d-rule); margin: 0 12px 4px;
+}
+.aq-desk .d-side .footstats {
+  margin-top: auto;
+  padding: 12px 14px; border-top: 1px solid var(--d-rule);
+}
+.aq-desk .d-side .footstats .v {
+  font-family: var(--font-mono); font-weight: 700;
+  font-size: 22px; letter-spacing: -0.02em; color: var(--d-fg);
+}
+.aq-desk .d-side .footstats .l {
+  font-size: 9.5px; letter-spacing: 0.14em;
+  color: var(--d-dim); margin-top: 2px;
+}
+.aq-desk .d-side .footstats .streak {
+  font-size: 10.5px; color: var(--d-dim); margin-top: 6px;
+  display: flex; align-items: center; gap: 6px;
+}
+.aq-desk .d-side .credit {
+  padding: 12px 14px;
+  border-top: 1px solid var(--d-rule);
+  font-size: 10px; color: var(--d-faint);
+  letter-spacing: 0.04em; line-height: 1.5;
+}
+.aq-desk .d-side .credit b { color: var(--d-fg); font-weight: 600; }
+
+/* main area */
+.aq-desk .d-main {
+  display: flex; flex-direction: column;
+  min-width: 0;
+}
+.aq-desk .d-bar {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 14px 22px; border-bottom: 1px solid var(--d-rule);
+  gap: 12px; flex-wrap: wrap;
+}
+.aq-desk .d-bar .crumbs {
+  font-size: 10.5px; letter-spacing: 0.14em;
+  color: var(--d-dim); display: flex; gap: 10px; align-items: center;
+}
+.aq-desk .d-bar .crumbs .now { color: var(--d-fg); }
+.aq-desk .d-bar .actions { display: flex; gap: 8px; }
+.aq-desk .d-bar .actions .btn {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 700;
+  letter-spacing: 0.06em;
+  padding: 8px 14px; border: 1px solid var(--d-rule);
+  color: var(--d-fg); display: inline-flex; align-items: center; gap: 6px;
+}
+.aq-desk .d-bar .actions .btn.lime {
+  background: var(--d-lime); color: var(--d-bg); border-color: var(--d-lime);
+}
+.aq-desk .d-bar .actions .seg {
+  display: inline-flex; border: 1px solid var(--d-rule);
+}
+.aq-desk .d-bar .actions .seg span {
+  padding: 8px 12px; font-size: 11px; color: var(--d-dim);
+  letter-spacing: 0.06em;
+}
+.aq-desk .d-bar .actions .seg span.on { background: var(--d-lime); color: var(--d-bg); }
+
+.aq-desk .d-content {
+  padding: 22px; flex: 1;
+  display: flex; flex-direction: column; gap: 16px;
+  position: relative;
+}
+
+/* Dashboard project hero */
+.aq-desk .pj-hero { display: flex; gap: 22px; align-items: flex-start; }
+.aq-desk .pj-hero .l { flex: 1; }
+.aq-desk .pj-hero .meta {
+  display: flex; gap: 10px; align-items: center;
+  font-size: 10.5px; letter-spacing: 0.14em;
+  color: var(--d-dim);
+}
+.aq-desk .pj-hero .pill-drama {
+  background: rgba(192,230,86,0.18);
+  color: var(--d-lime); padding: 3px 7px;
+  border-radius: 3px; font-size: 10px;
+  font-weight: 700; letter-spacing: 0.16em;
+}
+.aq-desk .pj-hero h2 {
+  font-family: var(--font-sans); font-weight: 800;
+  font-size: clamp(28px, 4vw, 48px); letter-spacing: -0.025em;
+  line-height: 1; margin: 8px 0 6px;
+}
+.aq-desk .pj-hero h2 .hl { background: rgba(168,200,80,0.55); color: var(--d-fg); padding: 0 6px; }
+.aq-desk .pj-hero h2 .ghost { color: var(--d-dim); }
+.aq-desk .pj-hero .logline {
+  font-family: var(--font-sans); color: var(--d-dim);
+  font-size: 13.5px; line-height: 1.5; margin: 0 0 14px;
+}
+.aq-desk .pj-stats {
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  gap: 14px; margin: 0 0 14px;
+}
+.aq-desk .pj-stats .v {
+  font-family: var(--font-sans); font-weight: 800;
+  font-size: 22px; letter-spacing: -0.02em;
+}
+.aq-desk .pj-stats .l {
+  font-size: 9.5px; letter-spacing: 0.14em;
+  color: var(--d-dim); margin-top: 4px;
+}
+.aq-desk .pj-actions { display: flex; gap: 10px; }
+.aq-desk .pj-actions .a {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 10px 16px; border: 1px solid var(--d-rule);
+  font-size: 11px; letter-spacing: 0.06em; font-weight: 700;
+}
+.aq-desk .pj-actions .a.lime {
+  background: var(--d-lime); color: var(--d-bg); border-color: var(--d-lime);
+}
+.aq-desk .pj-cover {
+  width: 160px; height: 220px; flex-shrink: 0;
+  background: var(--d-paper); color: var(--d-bg);
+  display: flex; flex-direction: column; align-items: center;
+  padding: 30px 14px 14px;
+  font-family: var(--font-mono); font-size: 9px;
+  letter-spacing: 0.16em; text-align: center;
+  position: relative;
+}
+.aq-desk .pj-cover .wip {
+  position: absolute; top: 6px; right: 6px;
+  background: var(--d-lime); color: var(--d-bg);
+  font-size: 9px; padding: 2px 6px; font-weight: 700;
+  letter-spacing: 0.12em;
+}
+.aq-desk .pj-cover .ttl { font-weight: 700; margin-top: 24px; }
+.aq-desk .pj-cover .by { margin-top: auto; opacity: 0.7; }
+
+/* Tabs */
+.aq-desk .pj-tabs {
+  display: flex; gap: 22px;
+  border-top: 1px solid var(--d-rule);
+  border-bottom: 1px solid var(--d-rule);
+  padding: 11px 0; margin: 4px 0;
+  font-size: 11px; letter-spacing: 0.14em; color: var(--d-dim);
+}
+.aq-desk .pj-tabs .t.on { color: var(--d-fg); position: relative; }
+.aq-desk .pj-tabs .t.on::after {
+  content: ''; position: absolute; left: 0; right: 0; bottom: -12px;
+  height: 2px; background: var(--d-lime);
+}
+
+.aq-desk .pj-grid {
+  display: grid; grid-template-columns: 2fr 1fr; gap: 14px;
+}
+.aq-desk .panel {
+  border: 1px solid var(--d-rule);
+  padding: 14px;
+  display: flex; flex-direction: column; gap: 10px;
+}
+.aq-desk .panel h6 {
+  margin: 0;
+  font-size: 10.5px; letter-spacing: 0.16em; color: var(--d-fg);
+  font-weight: 700;
+  display: flex; justify-content: space-between;
+}
+.aq-desk .panel h6 .ic { color: var(--d-dim); }
+.aq-desk .panel .ph {
+  font-family: var(--font-sans); color: var(--d-faint);
+  font-size: 13px; font-style: italic;
+}
+.aq-desk .rhythm {
+  display: flex; gap: 4px; align-items: flex-end;
+  padding: 4px 0;
+}
+.aq-desk .rhythm .b {
+  flex: 1; height: 18px;
+  border: 1px solid var(--d-rule);
+}
+.aq-desk .rhythm .b.now { background: var(--d-lime); border-color: var(--d-lime); }
+.aq-desk .rhythm .b.warm { background: rgba(192,230,86,0.18); }
+.aq-desk .panel .row {
+  display: flex; justify-content: space-between;
+  font-size: 11px; padding: 6px 0;
+  border-top: 1px dashed var(--d-rule);
+  color: var(--d-dim);
+}
+.aq-desk .panel .row:first-child { border-top: 0; }
+.aq-desk .panel .row .v { color: var(--d-fg); }
+
+/* CMDK overlay (in-mockup) */
+.aq-desk .desk-cmdk {
+  position: absolute; top: 60px; left: 50%;
+  transform: translateX(-50%);
+  width: min(560px, 80%);
+  background: var(--d-card);
+  border: 1px solid var(--d-paper);
+  box-shadow: 0 24px 64px rgba(0,0,0,0.6), 0 0 0 4px rgba(239,232,214,0.06);
+  font-family: var(--font-mono);
+  z-index: 5;
+}
+.aq-desk .desk-cmdk .cmd-input {
+  display: flex; align-items: center; gap: 10px;
+  padding: 14px 16px; border-bottom: 1px solid var(--d-rule);
+}
+.aq-desk .desk-cmdk .cmd-input .icn { color: var(--d-dim); font-size: 14px; }
+.aq-desk .desk-cmdk .cmd-input input {
+  flex: 1; background: transparent; border: 0; outline: 0;
+  font-family: inherit; font-size: 13px; color: var(--d-fg);
+}
+.aq-desk .desk-cmdk .cmd-input input::placeholder { color: var(--d-faint); }
+.aq-desk .desk-cmdk .cmd-input .x { color: var(--d-dim); font-size: 12px; }
+.aq-desk .desk-cmdk .grp {
+  font-size: 9.5px; padding: 10px 16px 4px;
+  letter-spacing: 0.16em; color: var(--d-faint); text-transform: uppercase;
+}
+.aq-desk .desk-cmdk .ci {
+  display: flex; align-items: center; gap: 12px;
+  padding: 11px 16px; font-size: 13px; color: var(--d-dim);
+}
+.aq-desk .desk-cmdk .ci .glyph { width: 18px; opacity: 0.7; }
+.aq-desk .desk-cmdk .ci .ctx {
+  margin-left: auto; color: var(--d-faint); font-size: 11px;
+  letter-spacing: 0.04em;
+}
+.aq-desk .desk-cmdk .ci.on {
+  background: var(--d-lime); color: var(--d-bg); font-weight: 700;
+}
+.aq-desk .desk-cmdk .ci.on .glyph,
+.aq-desk .desk-cmdk .ci.on .ctx { color: var(--d-bg); }
+
+/* Library variants */
+.aq-desk.lib .lib-head {
+  display: flex; justify-content: space-between; align-items: flex-end;
+  border-bottom: 1px solid var(--d-rule);
+  padding-bottom: 10px;
+}
+.aq-desk.lib .lib-head .ttl {
+  font-family: var(--font-sans); font-weight: 800;
+  font-size: 28px; letter-spacing: -0.02em;
+}
+.aq-desk.lib .lib-head .ttl .meta { font-family: var(--font-mono); font-size: 11px; color: var(--d-dim); display: block; font-weight: 500; letter-spacing: 0.14em; margin-bottom: 6px; }
+.aq-desk.lib .shelf {
+  border: 1px dashed var(--d-rule);
+  padding: 16px; display: flex; gap: 14px; align-items: center;
+}
+.aq-desk.lib .shelf .glyph {
+  width: 36px; height: 36px; background: var(--d-lime);
+  display: grid; place-items: center; color: var(--d-bg);
+  border-radius: 4px; font-weight: 700;
+}
+.aq-desk.lib .shelf .l { flex: 1; }
+.aq-desk.lib .shelf .l .h { font-family: var(--font-sans); font-weight: 700; font-size: 14px; }
+.aq-desk.lib .shelf .l .s { font-family: var(--font-sans); font-size: 12px; color: var(--d-dim); margin-top: 2px; }
+.aq-desk.lib .shelf .acts { display: flex; gap: 6px; }
+.aq-desk.lib .shelf .acts .b {
+  padding: 7px 11px; border: 1px solid var(--d-rule);
+  font-size: 10.5px; color: var(--d-fg); letter-spacing: 0.06em;
+}
+.aq-desk.lib .search-row {
+  display: flex; gap: 10px; flex-wrap: wrap;
+  align-items: center;
+}
+.aq-desk.lib .search-row .input {
+  flex: 1; min-width: 220px;
+  border: 1px solid var(--d-rule); padding: 9px 12px;
+  font-size: 12px; color: var(--d-dim); letter-spacing: 0.04em;
+  display: flex; gap: 8px; align-items: center;
+}
+.aq-desk.lib .search-row .input .kbd { margin-left: auto; font-size: 10px; color: var(--d-faint); border: 1px solid var(--d-rule); padding: 1px 5px; }
+.aq-desk.lib .search-row .chip {
+  padding: 7px 12px; border: 1px solid var(--d-rule);
+  font-size: 10.5px; color: var(--d-fg); letter-spacing: 0.06em;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.aq-desk.lib .search-row .chip .n { color: var(--d-dim); }
+.aq-desk.lib .search-row .chip.on { background: var(--d-paper); color: var(--d-bg); border-color: var(--d-paper); }
+.aq-desk.lib .search-row .chip.on .n { color: var(--d-bg); }
+.aq-desk.lib .scripts {
+  border: 1px solid var(--d-rule);
+  padding: 0;
+}
+.aq-desk.lib .scripts .row {
+  display: grid; grid-template-columns: 28px 36px 1fr 60px 130px auto auto 18px;
+  gap: 12px; padding: 11px 12px; align-items: center;
+  border-top: 1px solid var(--d-rule);
+  font-size: 11.5px;
+}
+.aq-desk.lib .scripts .row:first-child { border-top: 0; }
+.aq-desk.lib .scripts .row .gi {
+  width: 28px; height: 28px; border: 1px solid var(--d-rule);
+  display: grid; place-items: center; font-family: var(--font-mono);
+  font-size: 10px; color: var(--d-fg);
+}
+.aq-desk.lib .scripts .row .ttl { font-family: var(--font-sans); font-weight: 700; font-size: 13px; color: var(--d-fg); letter-spacing: -0.005em; }
+.aq-desk.lib .scripts .row .yr { font-family: var(--font-mono); color: var(--d-dim); }
+.aq-desk.lib .scripts .row .by { color: var(--d-dim); }
+.aq-desk.lib .scripts .row .tag {
+  padding: 3px 8px; font-size: 9.5px; letter-spacing: 0.14em;
+  border: 1px solid var(--d-rule); color: var(--d-fg);
+}
+.aq-desk.lib .scripts .row .tag.lime { background: var(--d-lime); color: var(--d-bg); border-color: var(--d-lime); font-weight: 700; }
+.aq-desk.lib .scripts .row .bm { color: var(--d-faint); text-align: right; }
+
+.aq-desk-cap {
+  margin-top: 12px;
+  text-align: center; font-family: var(--font-mono);
+  font-size: 11px; color: var(--fg-faint);
+  letter-spacing: 0.08em; text-transform: uppercase;
+}
+.aq-desk-cap em { color: var(--fg-dim); font-style: italic; text-transform: none; }
+
+@media (max-width: 880px) {
+  .aq-desk { grid-template-columns: 1fr; }
+  .aq-desk .d-side { display: none; }
+  .aq-desk .pj-hero { flex-direction: column; }
+  .aq-desk .pj-cover { width: 100%; height: auto; padding: 18px; }
+  .aq-desk .pj-grid { grid-template-columns: 1fr; }
+  .aq-desk .pj-stats { grid-template-columns: repeat(3, 1fr); }
+}
 </style>
 </head>
 <body>
@@ -810,80 +1318,222 @@
   </div>
 </section>
 
-<div class="aq-phone-wrap">
-  <div class="aq-phone">
-    <div class="aq-app inspire">
-      <div class="ph-head">
-        <div class="h">INSPIRE</div>
-        <div class="chips">
-          <span class="chip flame">🔥 1</span>
-          <span class="chip xp">⚡ 20</span>
+<div class="aq-phones-row">
+  <!-- WRITE — mobile editor with element-cycling toolbar -->
+  <div>
+    <div class="aq-phone">
+      <div class="aq-app editor-mobile">
+        <div class="me-statusbar">
+          <span class="ic">←</span>
+          <span class="ttl">Still Life Wi… <span class="arrow">▾</span></span>
+          <span class="saved">SAVED</span>
+          <span class="meta">1,013 W &nbsp;/&nbsp; 5P</span>
+          <span class="ic">↶</span>
+          <span class="ic">⋮</span>
         </div>
-      </div>
-      <div class="tabs">
-        <span class="tab on">FEATURE</span>
-        <span class="tab">TV</span>
-        <span class="tab lock">PLAY 🔒</span>
-        <span class="tab lock">PROSE 🔒</span>
-      </div>
-      <div class="week">
-        <div><div class="day">M</div><div class="week-l">M</div></div>
-        <div><div class="day now">?</div><div class="week-l">T</div></div>
-        <div><div class="day">W</div><div class="week-l">W</div></div>
-        <div><div class="day">T</div><div class="week-l">T</div></div>
-        <div><div class="day">F</div><div class="week-l">F</div></div>
-        <div><div class="day">S</div><div class="week-l">S</div></div>
-        <div><div class="day">S</div><div class="week-l">S</div></div>
-      </div>
-      <div class="unit-banner">
-        <div>
-          <div class="l">UNIT 2 · FEATURE FILM</div>
-          <div class="t">BUILDING THE SCENE</div>
+        <div class="me-toolbar">
+          <span class="pill lime">≡</span>
+          <span class="pill dim">▥</span>
+          <span class="pill dim">⊞</span>
+          <span class="pill">SCENE</span>
+          <span class="pill lime">ACTION</span>
+          <span class="pill">CHAR</span>
+          <span class="pill">DIALOG</span>
         </div>
-        <div class="pill">1 / 7</div>
-      </div>
-      <div class="ladder">
-        <div class="step r">
-          <div class="lbl">OPEN ON CONFLICT<span class="meta">4 min · +40 XP</span></div>
-          <div class="node done">✓<span class="start-here" style="position:absolute;margin-left:60px">START HERE ▾</span></div>
+        <div class="me-script">
+          <div class="block"><span class="grip">⋮⋮</span><div class="body">connecticut strip mall. Gilt frames, mat board, a rosewood counter that has seen better paintings. The bell over the door is real brass and insists on being</div></div>
+          <div class="block"><span class="grip">⋮⋮</span><div class="body">CORA HALLIDAY (64, gray bob, the kind of glasses serious women retire into) is at the counter. A suburban WOMAN has laid a small canvas in front of her. Cora isn't looking at the painting. She's</div></div>
+          <div class="block ph"><span class="grip">⋮⋮</span><div class="body">Describe what we see and hear…</div></div>
+          <div class="block ph"><span class="grip">⋮⋮</span><div class="body">Describe what we see and hear…</div></div>
         </div>
-        <div class="step l">
-          <div class="node now">▶</div>
-          <div class="lbl">SHOW DON'T TELL<span class="meta">5 min · +60 XP</span></div>
+        <div class="me-elements">
+          <span class="pill">SLUG</span>
+          <span class="pill on">ACTION</span>
+          <span class="pill">CHAR</span>
+          <span class="pill">DIAL</span>
+          <span class="pill">(PAREN)</span>
+          <span class="pill">TRANS</span>
         </div>
-        <div class="step r">
-          <div class="lbl">BURY THE BACKSTORY<span class="meta">6 min · +60 XP</span></div>
-          <div class="node">🔒</div>
+        <div class="me-botnav">
+          <div class="it on"><span>✎</span>WRITE</div>
+          <div class="it"><span>📁</span>FILES</div>
+          <div class="it"><span>▥</span>LIBRARY</div>
+          <div class="it"><span>✦</span>INSPIRE</div>
+          <div class="it"><span>◔</span>PROFILE</div>
         </div>
-        <div class="step l">
-          <div class="node">🔒</div>
-          <div class="lbl">THE SILENT SCENE<span class="meta">5 min · +80 XP</span></div>
-        </div>
-        <div class="step r">
-          <div class="lbl">REVERSE THE POWER<span class="meta">7 min · +80 XP</span></div>
-          <div class="node">🔒</div>
-        </div>
-        <div class="step l">
-          <div class="node">🔒</div>
-          <div class="lbl">LAND THE BUTTON<span class="meta">5 min · +80 XP</span></div>
-        </div>
-        <div class="step l">
-          <div class="node">🔒</div>
-          <div class="lbl">PAGES 1–10<span class="meta">12 min · +200 XP</span></div>
-        </div>
-      </div>
-      <div class="cta">▷ START TODAY'S DRILL</div>
-      <div class="botnav">
-        <div class="it"><span>✎</span>WRITE</div>
-        <div class="it"><span>📁</span>FILES</div>
-        <div class="it"><span>▥</span>LIBRARY</div>
-        <div class="it on"><span>✦</span>INSPIRE</div>
-        <div class="it"><span>◔</span>PROFILE</div>
       </div>
     </div>
+    <div class="aq-phone-tag">WRITE · ACTION MODE</div>
+  </div>
+
+  <!-- INSPIRE -->
+  <div>
+    <div class="aq-phone">
+      <div class="aq-app inspire">
+        <div class="ph-head">
+          <div class="h">INSPIRE</div>
+          <div class="chips">
+            <span class="chip flame">🔥 1</span>
+            <span class="chip xp">⚡ 20</span>
+          </div>
+        </div>
+        <div class="tabs">
+          <span class="tab on">FEATURE</span>
+          <span class="tab">TV</span>
+          <span class="tab lock">PLAY 🔒</span>
+          <span class="tab lock">PROSE 🔒</span>
+        </div>
+        <div class="week">
+          <div><div class="day">M</div><div class="week-l">M</div></div>
+          <div><div class="day now">?</div><div class="week-l">T</div></div>
+          <div><div class="day">W</div><div class="week-l">W</div></div>
+          <div><div class="day">T</div><div class="week-l">T</div></div>
+          <div><div class="day">F</div><div class="week-l">F</div></div>
+          <div><div class="day">S</div><div class="week-l">S</div></div>
+          <div><div class="day">S</div><div class="week-l">S</div></div>
+        </div>
+        <div class="unit-banner">
+          <div>
+            <div class="l">UNIT 2 · FEATURE FILM</div>
+            <div class="t">BUILDING THE SCENE</div>
+          </div>
+          <div class="pill">1 / 7</div>
+        </div>
+        <div class="ladder">
+          <div class="step r">
+            <div class="lbl">OPEN ON CONFLICT<span class="meta">4 min · +40 XP</span></div>
+            <div class="node done">✓</div>
+          </div>
+          <div class="step l">
+            <div class="node now">▶</div>
+            <div class="lbl">SHOW DON'T TELL<span class="meta">5 min · +60 XP</span></div>
+          </div>
+          <div class="step r">
+            <div class="lbl">BURY THE BACKSTORY<span class="meta">6 min · +60 XP</span></div>
+            <div class="node">🔒</div>
+          </div>
+          <div class="step l">
+            <div class="node">🔒</div>
+            <div class="lbl">THE SILENT SCENE<span class="meta">5 min · +80 XP</span></div>
+          </div>
+          <div class="step r">
+            <div class="lbl">REVERSE THE POWER<span class="meta">7 min · +80 XP</span></div>
+            <div class="node">🔒</div>
+          </div>
+        </div>
+        <div class="cta">▷ START TODAY'S DRILL</div>
+        <div class="botnav">
+          <div class="it"><span>✎</span>WRITE</div>
+          <div class="it"><span>📁</span>FILES</div>
+          <div class="it"><span>▥</span>LIBRARY</div>
+          <div class="it on"><span>✦</span>INSPIRE</div>
+          <div class="it"><span>◔</span>PROFILE</div>
+        </div>
+      </div>
+    </div>
+    <div class="aq-phone-tag">INSPIRE · DRILLS</div>
+  </div>
+
+  <!-- EXPORT -->
+  <div>
+    <div class="aq-phone">
+      <div class="aq-app export">
+        <div class="grab"></div>
+        <div class="x-head">
+          <div>
+            <h4>Export Script</h4>
+            <p class="sub">Still Life With Daggers</p>
+          </div>
+          <span class="close">✕</span>
+        </div>
+        <div class="x-stats">
+          <div><div class="v">8</div><div class="l">SCENES</div></div>
+          <div><div class="v">1,013</div><div class="l">WORDS</div></div>
+          <div><div class="v">5</div><div class="l">EST. PAGES</div></div>
+        </div>
+        <div class="x-section first">
+          <h6>SCRIPT FORMAT</h6>
+          <div class="fmt-grid">
+            <div class="fmt">
+              <div class="icon"></div>
+              <span class="new">NEW</span>
+              <div class="name">Arqo (.arq)</div>
+              <div class="desc">Native · round-trips</div>
+            </div>
+            <div class="fmt on">
+              <div class="icon"></div>
+              <div class="name">PDF</div>
+              <div class="desc">Courier 12 · coloured pages</div>
+            </div>
+            <div class="fmt">
+              <div class="icon"></div>
+              <div class="name">FDX</div>
+              <div class="desc">Final Draft · lossless</div>
+            </div>
+            <div class="fmt">
+              <div class="icon"></div>
+              <div class="name">DOCX</div>
+              <div class="desc">Word · Docs · Pages</div>
+            </div>
+          </div>
+        </div>
+        <div class="x-section">
+          <h6>OPTIONS</h6>
+          <div class="options">
+            <div class="opt"><span>Include title page</span><span class="toggle"></span></div>
+            <div class="opt"><span>Include scene notes</span><span class="toggle"></span></div>
+            <div class="opt"><span>Coloured revision</span><span class="toggle off"></span></div>
+          </div>
+        </div>
+        <div class="x-foot">
+          <div class="export-btn">⬇ &nbsp;EXPORT PDF</div>
+        </div>
+      </div>
+    </div>
+    <div class="aq-phone-tag">EXPORT · 4 TARGETS</div>
+  </div>
+
+  <!-- PROFILE -->
+  <div>
+    <div class="aq-phone">
+      <div class="aq-app profile">
+        <div class="top-tabs">
+          <div class="t on">PROFILE</div>
+          <div class="t">FRIENDS</div>
+        </div>
+        <div class="sub-tabs">
+          <div class="t on">ACTIVITY</div>
+          <div class="t">ACCOUNT</div>
+          <div class="t">WRITING</div>
+          <div class="t">DISPLAY</div>
+        </div>
+        <div class="who">
+          <div class="at">@raghava</div>
+          <div class="signout">⎋ &nbsp;SIGN OUT</div>
+        </div>
+        <div class="heatmap">
+          <div class="heatmap-grid" id="heat-grid"></div>
+        </div>
+        <div class="recent">
+          <h6>RECENT ACTIVITY</h6>
+          <div class="row"><span class="when">12M AGO</span><span class="what">Wrote 1,013 words on <span class="hl">Still Life With Daggers</span></span></div>
+          <div class="row"><span class="when">2H AGO</span><span class="what">Resolved a thread on <span class="hl">The Last Pattern</span></span></div>
+          <div class="row"><span class="when">YESTERDAY</span><span class="what">Started a new short, <span class="hl">Quiet Streets</span></span></div>
+          <div class="row"><span class="when">3 DAYS AGO</span><span class="what">Imported PDF: <span class="hl">Chinatown.pdf</span></span></div>
+        </div>
+        <div class="botnav">
+          <div class="it"><span>✎</span>WRITE</div>
+          <div class="it"><span>📁</span>FILES</div>
+          <div class="it"><span>▥</span>LIBRARY</div>
+          <div class="it"><span>✦</span>INSPIRE</div>
+          <div class="it on"><span>◔</span>PROFILE</div>
+        </div>
+      </div>
+    </div>
+    <div class="aq-phone-tag">PROFILE · ACTIVITY</div>
   </div>
 </div>
-<p class="aq-phone-cap">↑ inspire · creator-tier daily drill ladder, <em>building the scene</em> unit</p>
+<p class="aq-phone-cap">↑ four mobile surfaces · <em>write · inspire · export · profile</em> — same AST, different posture</p>
 
 <section class="chapter">
   <div class="col col-narrow prose">
@@ -927,6 +1577,80 @@
     <p>Editor state lives locally (Zustand store), mirrored into IndexedDB (offline), and for shared projects into a Yjs CRDT running through a Liveblocks provider. Writes are local-first; a background queue reconciles with the server when online. Conflict resolution is handled by the CRDT — no manual merge UI required for element-level edits.</p>
   </div>
 </section>
+
+<div class="col aq-desk-wrap">
+  <div class="aq-desk">
+    <aside class="d-side">
+      <div class="wm">arqo<span class="dot">.</span><span class="pull">⌘</span></div>
+      <h6 style="margin-top:6px">CRAFT</h6>
+      <div class="nav">
+        <div class="item"><span class="ic">▢</span>PROJECTS</div>
+        <div class="item"><span class="ic">▥</span>LIBRARY</div>
+        <div class="item"><span class="ic">✎</span>WRITE</div>
+        <div class="item"><span class="ic">✦</span>INSPIRE</div>
+      </div>
+      <h6 style="margin-top:6px">YOU</h6>
+      <div class="nav">
+        <div class="item"><span class="ic">◔</span>PROFILE</div>
+      </div>
+      <div class="footstats">
+        <div style="font-size:9.5px;letter-spacing:0.16em;color:var(--d-dim);margin-bottom:6px">TODAY</div>
+        <div class="v">1,213 <span style="font-size:11px;color:var(--d-dim);font-weight:500">words</span></div>
+        <div class="streak">🔥 5-day streak</div>
+      </div>
+    </aside>
+    <div class="d-main">
+      <div class="d-bar">
+        <div class="crumbs"><span>←</span><span>PROJECTS</span><span>/</span><span class="now">STILL LIFE WITH DAGGERS</span></div>
+        <div class="actions">
+          <div class="seg"><span class="on">⌘K COMMANDS</span></div>
+        </div>
+      </div>
+      <div class="d-content" style="opacity:0.45;filter:blur(0.4px)">
+        <div class="pj-hero">
+          <div class="l">
+            <div class="meta">
+              <span class="pill-drama">DRAMA</span>
+              <span>SHORT · DRAFT IN PROGRESS</span>
+            </div>
+            <h2><span class="hl">STILL</span> LIFE WITH <span class="ghost">DAGGERS</span></h2>
+            <p class="logline">Add a logline to summarize your story in one sentence…</p>
+            <div class="pj-stats">
+              <div><div class="v">1,013</div><div class="l">WORDS</div></div>
+              <div><div class="v">5</div><div class="l">PAGES</div></div>
+              <div><div class="v">8</div><div class="l">SCENES</div></div>
+              <div><div class="v">5</div><div class="l">CHARS</div></div>
+              <div><div class="v">7</div><div class="l">LOCATIONS</div></div>
+            </div>
+          </div>
+          <div class="pj-cover">
+            <span class="wip">WIP</span>
+            <div class="ttl">STILL LIFE<br>WITH DAGGERS</div>
+            <div style="margin-top:auto">A SHORT SCREENPLAY</div>
+            <div class="by">BY DEMO WRITER</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ⌘K palette overlay -->
+      <div class="desk-cmdk">
+        <div class="cmd-input">
+          <span class="icn">🔍</span>
+          <input value="Type a command, or ? to ask the script…" readonly/>
+          <span class="x">✕</span>
+        </div>
+        <div class="grp">NAVIGATE</div>
+        <div class="ci on"><span class="glyph">▦</span><span>Go to Projects</span></div>
+        <div class="ci"><span class="glyph">✎</span><span>Open Writing Pad</span><span class="ctx">Still Life With Daggers</span></div>
+        <div class="ci"><span class="glyph">▦</span><span>Open Beats</span></div>
+        <div class="ci"><span class="glyph">◐</span><span>Open Characters</span></div>
+        <div class="ci"><span class="glyph">✦</span><span>Open Inspire</span></div>
+        <div class="ci"><span class="glyph">▥</span><span>Open Library</span></div>
+      </div>
+    </div>
+  </div>
+  <div class="aq-desk-cap">↑ ⌘K · the same command surface available from every page · <em>type a command, or ? to ask the script</em></div>
+</div>
 
 <section class="chapter" id="engineering">
   <div class="col col-narrow prose">
@@ -979,63 +1703,110 @@ Paginator responsibilities:
   </div>
 </section>
 
-<div class="aq-phone-wrap">
-  <div class="aq-phone">
-    <div class="aq-app export">
-      <div class="grab"></div>
-      <div class="x-head">
-        <div>
-          <h4>Export Script</h4>
-          <p class="sub">Still Life With Daggers</p>
-        </div>
-        <span class="close">✕</span>
+<div class="col aq-desk-wrap">
+  <div class="aq-desk">
+    <aside class="d-side">
+      <div class="wm">arqo<span class="dot">.</span><span class="pull">⌘</span></div>
+      <h6 style="margin-top:6px">CRAFT</h6>
+      <div class="nav">
+        <div class="item"><span class="ic">▢</span>PROJECTS</div>
+        <div class="item"><span class="ic">▥</span>LIBRARY</div>
+        <div class="item on"><span class="ic">✎</span>WRITE</div>
       </div>
-      <div class="x-stats">
-        <div><div class="v">8</div><div class="l">SCENES</div></div>
-        <div><div class="v">1,013</div><div class="l">WORDS</div></div>
-        <div><div class="v">5</div><div class="l">EST. PAGES</div></div>
+      <div class="sub">
+        <div class="pin">Still Life With Daggers <span style="color:var(--d-faint)">×</span></div>
+        <div class="si on">DASHBOARD</div>
+        <div class="si">WRITE</div>
+        <div class="si">BEATS</div>
+        <div class="si">CHARACTERS</div>
+        <div class="si">LOCATIONS</div>
+        <div class="si">RESEARCH</div>
       </div>
-      <div class="x-section first">
-        <h6>SCRIPT FORMAT</h6>
-        <div class="fmt-grid">
-          <div class="fmt">
-            <div class="icon"></div>
-            <span class="new">NEW</span>
-            <div class="name">Arqo (.arq)</div>
-            <div class="desc">Native · round-trips everything</div>
-          </div>
-          <div class="fmt on">
-            <div class="icon"></div>
-            <div class="name">PDF</div>
-            <div class="desc">Courier 12 · coloured pages on issue</div>
-          </div>
-          <div class="fmt">
-            <div class="icon"></div>
-            <div class="name">FDX</div>
-            <div class="desc">Final Draft · lossless</div>
-          </div>
-          <div class="fmt">
-            <div class="icon"></div>
-            <div class="name">DOCX</div>
-            <div class="desc">Word · Docs · Pages</div>
-          </div>
+      <div class="item"><span class="ic">✦</span>INSPIRE</div>
+      <h6 style="margin-top:6px">YOU</h6>
+      <div class="nav">
+        <div class="item"><span class="ic">◔</span>PROFILE</div>
+      </div>
+      <div class="footstats">
+        <div style="font-size:9.5px;letter-spacing:0.16em;color:var(--d-dim);margin-bottom:6px">TODAY</div>
+        <div class="v">1,213 <span style="font-size:11px;color:var(--d-dim);font-weight:500">words</span></div>
+        <div class="streak">🔥 5-day streak</div>
+      </div>
+      <div class="credit">arqo<span style="color:var(--d-lime)">.</span><br>Built by <b>Isabella Vizetta</b> and <b>Raghav Ahuja</b> using Next.js and a lot of diet soda.</div>
+    </aside>
+    <div class="d-main">
+      <div class="d-bar">
+        <div class="crumbs"><span>←</span><span>PROJECTS</span><span>/</span><span class="now">STILL LIFE WITH DAGGERS</span></div>
+        <div class="actions">
+          <div class="seg"><span class="on">⌘K COMMANDS</span></div>
         </div>
       </div>
-      <div class="x-section">
-        <h6>OPTIONS</h6>
-        <div class="options">
-          <div class="opt"><span>Include title page</span><span class="toggle"></span></div>
-          <div class="opt"><span>Include scene notes</span><span class="toggle"></span></div>
-          <div class="opt"><span>Coloured revision pages</span><span class="toggle off"></span></div>
+      <div class="d-content">
+        <div class="pj-hero">
+          <div class="l">
+            <div class="meta">
+              <span class="pill-drama">DRAMA</span>
+              <span>SHORT · DRAFT IN PROGRESS · LAST EDIT MAY 5, 2026</span>
+            </div>
+            <h2><span class="hl">STILL</span> LIFE WITH <span class="ghost">DAGGERS</span></h2>
+            <p class="logline">Add a logline to summarize your story in one sentence…</p>
+            <div class="pj-stats">
+              <div><div class="v">1,013</div><div class="l">WORDS</div></div>
+              <div><div class="v">5</div><div class="l">PAGES</div></div>
+              <div><div class="v">8</div><div class="l">SCENES</div></div>
+              <div><div class="v">5</div><div class="l">CHARACTERS</div></div>
+              <div><div class="v">7</div><div class="l">LOCATIONS</div></div>
+            </div>
+            <div class="pj-actions">
+              <span class="a lime">✎ &nbsp;RESUME WRITING</span>
+              <span class="a">↗ &nbsp;SHARE</span>
+              <span class="a">⬇ &nbsp;EXPORT</span>
+            </div>
+          </div>
+          <div class="pj-cover">
+            <span class="wip">WIP</span>
+            <div class="ttl">STILL LIFE<br>WITH DAGGERS</div>
+            <div style="margin-top:auto">A SHORT SCREENPLAY</div>
+            <div class="by">BY DEMO WRITER</div>
+          </div>
         </div>
-      </div>
-      <div class="x-foot">
-        <div class="export-btn">⬇ &nbsp;EXPORT PDF</div>
+        <div class="pj-tabs">
+          <span class="t on">OVERVIEW</span>
+          <span class="t">BEATS</span>
+          <span class="t">CHARACTERS</span>
+          <span class="t">LOCATIONS</span>
+          <span class="t">REPORTS</span>
+          <span class="t">INBOX&nbsp;0</span>
+        </div>
+        <div class="pj-grid">
+          <div class="panel">
+            <h6>WRITER'S RHYTHM <span class="ic">30-DAY LOG</span></h6>
+            <div class="rhythm">
+              <span class="b"></span><span class="b"></span><span class="b"></span><span class="b warm"></span>
+              <span class="b"></span><span class="b warm"></span><span class="b"></span><span class="b"></span>
+              <span class="b warm"></span><span class="b"></span><span class="b"></span><span class="b warm"></span>
+              <span class="b"></span><span class="b"></span><span class="b"></span><span class="b warm"></span>
+              <span class="b"></span><span class="b"></span><span class="b warm"></span><span class="b"></span>
+              <span class="b warm"></span><span class="b"></span><span class="b"></span><span class="b"></span>
+              <span class="b warm"></span><span class="b"></span><span class="b"></span><span class="b"></span>
+              <span class="b"></span><span class="b now"></span>
+            </div>
+            <div class="row" style="border-top:1px solid var(--d-rule);margin-top:6px;padding-top:8px"><span>TODAY · KEEP THE CADENCE</span><span class="v">NO FLAME, NO PAGE</span></div>
+          </div>
+          <div class="panel">
+            <h6>GENRE · TONE</h6>
+            <p class="ph">No genres or tones set yet.</p>
+            <div class="row"><span>FORMAT</span><span class="v">SHORT</span></div>
+            <div class="row"><span>STARTED</span><span class="v">APR 30, 26</span></div>
+            <div class="row"><span>LAST EDIT</span><span class="v">MAY 5, 26</span></div>
+            <div class="row"><span>PAGE</span><span class="v">5</span></div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
+  <div class="aq-desk-cap">↑ project dashboard · <em>still life with daggers</em> · writer's hub on desktop</div>
 </div>
-<p class="aq-phone-cap">↑ export sheet · <em>Arqo (.arq) · PDF · FDX · DOCX</em> — same AST, four targets</p>
 
 <section class="chapter">
   <div class="col col-narrow prose">
@@ -1135,49 +1906,128 @@ Paginator responsibilities:
       <li>Initial load (web): ~85KB critical path gzipped. Editor code lazy-loaded.</li>
       <li>Mobile Lighthouse target: ≥90 Perf, A11y, Best Practices.</li>
     </ul>
-    <p>The performance budget exists for the feel, not the spec sheet. Every keystroke fires off the paginator, the autosave, and the activity-log emitter — and none of them are allowed to stall the editor. The activity log is what powers the writer's habit feedback loop, shown opposite.</p>
+    <p>The performance budget exists for the feel, not the spec sheet. Every keystroke fires off the paginator, the autosave, and the activity-log emitter — and none of them are allowed to stall the editor. The activity log is what powers the writer's habit feedback loop on the profile surface (above).</p>
   </div>
 </section>
 
-<div class="aq-phone-wrap">
-  <div class="aq-phone">
-    <div class="aq-app profile">
-      <div class="top-tabs">
-        <div class="t on">PROFILE</div>
-        <div class="t">FRIENDS</div>
+<div class="col aq-desk-wrap">
+  <div class="aq-desk lib">
+    <aside class="d-side">
+      <div class="wm">arqo<span class="dot">.</span><span class="pull">⌘</span></div>
+      <h6 style="margin-top:6px">CRAFT</h6>
+      <div class="nav">
+        <div class="item"><span class="ic">▢</span>PROJECTS</div>
+        <div class="item on"><span class="ic">▥</span>LIBRARY</div>
+        <div class="item"><span class="ic">✎</span>WRITE</div>
+        <div class="item"><span class="ic">✦</span>INSPIRE</div>
       </div>
-      <div class="sub-tabs">
-        <div class="t on">ACTIVITY</div>
-        <div class="t">ACCOUNT</div>
-        <div class="t">WRITING</div>
-        <div class="t">DISPLAY</div>
+      <h6 style="margin-top:6px">YOU</h6>
+      <div class="nav">
+        <div class="item"><span class="ic">◔</span>PROFILE</div>
       </div>
-      <div class="who">
-        <div class="at">@raghava</div>
-        <div class="signout">⎋ &nbsp;SIGN OUT</div>
+      <div class="footstats">
+        <div style="font-size:9.5px;letter-spacing:0.16em;color:var(--d-dim);margin-bottom:6px">TODAY</div>
+        <div class="v">1,213 <span style="font-size:11px;color:var(--d-dim);font-weight:500">words</span></div>
+        <div class="streak">🔥 5-day streak</div>
+        <div style="font-size:10px;color:var(--d-dim);margin-top:10px;letter-spacing:0.06em">☀ LIGHT MODE</div>
       </div>
-      <div class="heatmap">
-        <div class="heatmap-grid" id="heat-grid"></div>
+    </aside>
+    <div class="d-main">
+      <div class="d-bar">
+        <div class="crumbs"><span>LIBRARY · 1,230 REFERENCE SCRIPTS</span></div>
+        <div class="actions">
+          <span class="btn">⬆ IMPORT</span>
+          <span class="btn lime">▥ BROWSE THE SELECT</span>
+          <div class="seg"><span class="on">SCRIPTS</span><span>BOOKS</span></div>
+        </div>
       </div>
-      <div class="recent">
-        <h6>RECENT ACTIVITY</h6>
-        <div class="row"><span class="when">12M AGO</span><span class="what">Wrote 1,013 words on <span class="hl">Still Life With Daggers</span></span></div>
-        <div class="row"><span class="when">2H AGO</span><span class="what">Resolved a thread on <span class="hl">The Last Pattern</span></span></div>
-        <div class="row"><span class="when">YESTERDAY</span><span class="what">Started a new short, <span class="hl">Quiet Streets</span></span></div>
-        <div class="row"><span class="when">3 DAYS AGO</span><span class="what">Imported a PDF to library: <span class="hl">Chinatown.pdf</span></span></div>
-        <div class="row"><span class="when">5 DAYS AGO</span><span class="what">Reached scene 8 of <span class="hl">Still Life With Daggers</span></span></div>
-      </div>
-      <div class="botnav">
-        <div class="it"><span>✎</span>WRITE</div>
-        <div class="it"><span>📁</span>FILES</div>
-        <div class="it"><span>▥</span>LIBRARY</div>
-        <div class="it"><span>✦</span>INSPIRE</div>
-        <div class="it on"><span>◔</span>PROFILE</div>
+      <div class="d-content" style="gap:14px">
+        <h2 style="font-family:var(--font-sans);font-weight:800;font-size:28px;letter-spacing:-0.02em;margin:0">SCRIPTS</h2>
+
+        <div class="lib-head">
+          <div>
+            <div style="font-size:10.5px;letter-spacing:0.14em;color:var(--d-dim);text-transform:uppercase">YOUR SHELF</div>
+          </div>
+          <div style="font-size:10.5px;color:var(--d-dim);letter-spacing:0.08em">0 SCRIPTS · LOCAL TO THIS DEVICE</div>
+        </div>
+
+        <div class="shelf">
+          <span class="glyph">▢</span>
+          <div class="l"><div class="h">SAVE SCRIPTS TO READ LATER</div><div class="s">Tap the bookmark on any script below.</div></div>
+          <div class="acts">
+            <span class="b">⬆ &nbsp;IMPORT A PDF</span>
+            <span class="b">↗ &nbsp;FROM URL</span>
+          </div>
+        </div>
+
+        <div class="search-row">
+          <div class="input">🔍 &nbsp;Search title, writer, year, genre… <span class="kbd">⌘K</span></div>
+          <span class="chip on">ALL <span class="n">1,230</span></span>
+          <span class="chip">HOLLYWOOD <span class="n">772</span></span>
+          <span class="chip">BOLLYWOOD <span class="n">74</span></span>
+          <span class="chip">WORLD <span class="n">384</span></span>
+          <span class="chip">▥ THE SELECT <span class="n">12</span></span>
+        </div>
+
+        <div style="font-size:10px;letter-spacing:0.16em;color:var(--d-dim)">SHOWING 1 — 30 OF 1230</div>
+
+        <div class="scripts">
+          <div class="row">
+            <span></span>
+            <span class="gi">G</span>
+            <span class="ttl">THE GODFATHER</span>
+            <span class="yr">1972</span>
+            <span class="by">Puzo / Coppola</span>
+            <span class="tag">· CRIME</span>
+            <span class="tag lime">★ THE SELECT</span>
+            <span class="bm">▢</span>
+          </div>
+          <div class="row">
+            <span></span>
+            <span class="gi">PF</span>
+            <span class="ttl">PULP FICTION</span>
+            <span class="yr">1994</span>
+            <span class="by">Tarantino / Avary</span>
+            <span class="tag">· CRIME</span>
+            <span class="tag lime">★ THE SELECT</span>
+            <span class="bm">▢</span>
+          </div>
+          <div class="row">
+            <span></span>
+            <span class="gi">G</span>
+            <span class="ttl">GOODFELLAS</span>
+            <span class="yr">1990</span>
+            <span class="by">Pileggi / Scorsese</span>
+            <span class="tag">· CRIME</span>
+            <span></span>
+            <span class="bm">▢</span>
+          </div>
+          <div class="row">
+            <span></span>
+            <span class="gi">RD</span>
+            <span class="ttl">RESERVOIR DOGS</span>
+            <span class="yr">1992</span>
+            <span class="by">Quentin Tarantino</span>
+            <span class="tag">· CRIME</span>
+            <span></span>
+            <span class="bm">▢</span>
+          </div>
+          <div class="row">
+            <span></span>
+            <span class="gi">D</span>
+            <span class="ttl">THE DEPARTED</span>
+            <span class="yr">2006</span>
+            <span class="by">William Monahan</span>
+            <span class="tag">· CRIME</span>
+            <span></span>
+            <span class="bm">▢</span>
+          </div>
+        </div>
       </div>
     </div>
   </div>
+  <div class="aq-desk-cap">↑ library · 1,230 reference scripts · <em>the index that powers Voice Fingerprint &amp; Continuity Reader</em></div>
 </div>
-<p class="aq-phone-cap">↑ profile · activity · <em>habit feedback drives the writer's loop, quietly</em></p>
 <script>
 (function(){
   var g = document.getElementById('heat-grid'); if (!g) return;


### PR DESCRIPTION
## Summary

Follow-up to #48 — that PR was merged before this commit landed, so opening fresh against main.

- **⌘K fix** — the palette was rebuilding the entire DOM on every keystroke and every hover, which reset the input caret, stacked listeners, and never closed the overlay after a \`target=\"_blank\"\` click. Split into \`mountCmdk\` (chrome built once) + \`renderList\` (only the list re-renders). Hover and arrow keys now just toggle \`.sel\` on rows. All clicks close the overlay before navigating.
- **Mobile mockups grouped** — Inspire / Export / Profile + a new \`WRITE · ACTION MODE\` phone (mobile editor with element-cycling toolbar) consolidated into one horizontal phones row right after CH. 02 mobile-surfaces, scroll-snap on small screens, each phone tagged below.
- **Desktop arqo screens spread across the case study**:
  - **Project Dashboard** (CH. 04 · replaces the old solo Export-modal slot) — arqo. wordmark, CRAFT/YOU sidebar with the WRITE submenu expanded, STILL LIFE WITH DAGGERS hero, 5-stat row (1,013 W · 5P · 8 SC · 5 CH · 7 LOC), Resume / Share / Export pills, OVERVIEW/BEATS/CHARACTERS tabs, Writer's Rhythm panel with a 30-day cadence bar.
  - **Project Dashboard + ⌘K** (CH. 03 architecture · new) — same dashboard dimmed behind a centered ⌘K palette: \"Type a command, or ? to ask the script…\" with NAVIGATE group items (Go to Projects, Open Writing Pad, Open Beats, Open Characters, Open Inspire, Open Library) and the first item highlighted in lime.
  - **Library / Scripts** (CH. 09 · replaces the old solo Profile slot) — 1,230 reference scripts, ⌘K search bar, ALL/HOLLYWOOD/BOLLYWOOD/WORLD/THE SELECT chips, SHOWING 1—30 OF 1230, list rows for Godfather / Pulp Fiction / Goodfellas / Reservoir Dogs / The Departed each with genre tag and bookmark.

## Files changed

- [site.js](site.js) — cmdk rewrite
- [work/arqo.html](work/arqo.html) — phones row + 3 desktop mockups + CSS

## Test plan

- [ ] ⌘K opens, you can type without the caret jumping; hovering over a row no longer eats keystrokes
- [ ] ⌘K external item (email/social/file) opens in a new tab AND closes the overlay
- [ ] ⌘K internal item navigates AND closes the overlay
- [ ] /work/arqo: phones row scrolls horizontally on mobile, all four phones render
- [ ] /work/arqo: three desktop mockups (dashboard, dashboard+⌘K overlay, library) render at the right beats and stack on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)