### PR TITLE
P0 cleanup: remove EF password leak, wire MIND/HCAI, normalize claims

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,6 +116,12 @@
     font-family: var(--font-mono); font-size: 10.5px;
     letter-spacing: 0.18em; text-transform: uppercase;
     color: var(--heat); font-weight: 600;
+    display: flex; flex-direction: column; gap: 3px;
+  }
+  .now-row .h .stamp {
+    font-family: var(--font-mono); font-size: 9px;
+    letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--fg-faint); font-weight: 400;
   }
   .now-cell {
     font-size: 14px; line-height: 1.5; color: var(--fg);
@@ -457,7 +463,7 @@
 <section class="now">
   <div class="col">
     <div class="now-row">
-      <span class="h">NOW —</span>
+      <span class="h">NOW —<span class="stamp">updated 2026·05·06</span></span>
       <div class="now-cell">
         <span class="lbl">SHIP</span>
         <span><span class="live"></span>arqo v0.4 — paginator on a worker, FDX clean</span>

--- a/mamdani-mapper.html
+++ b/mamdani-mapper.html
@@ -198,7 +198,7 @@
   <footer class="mm-footer">
     <a href="/">↩ raghavahuja.com</a>
     <span>·</span>
-    <span>built by <a href="mamdani-mapper-case.html">Raghav Ahuja</a> using HTML and a lot of Diet Coke</span>
+    <span>built by <a href="/receipts/mamdani-mapper">Raghav Ahuja</a> using HTML and a lot of Diet Coke</span>
     <span>·</span>
     <span>cartography desk · brooklyn</span>
   </footer>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -5,6 +5,8 @@
   <url><loc>https://raghavahuja.com/work/arqo</loc><priority>0.9</priority></url>
   <url><loc>https://raghavahuja.com/work/jmnpr</loc><priority>0.8</priority></url>
   <url><loc>https://raghavahuja.com/work/ef</loc><priority>0.8</priority></url>
+  <url><loc>https://raghavahuja.com/work/mind</loc><priority>0.7</priority></url>
+  <url><loc>https://raghavahuja.com/work/hcai</loc><priority>0.7</priority></url>
   <url><loc>https://raghavahuja.com/receipts</loc><priority>0.8</priority></url>
   <url><loc>https://raghavahuja.com/receipts/mamdani-mapper</loc><priority>0.7</priority></url>
   <url><loc>https://raghavahuja.com/receipts/futbolis</loc><priority>0.7</priority></url>

--- a/work/ef.html
+++ b/work/ef.html
@@ -452,13 +452,6 @@
   </div>
 </section>
 
-<div class="col col-narrow prose">
-  <div class="aside" id="unlock-hint">
-    <span class="label">PASSWORD HINT (FRIENDLY)</span>
-    For testing this site: try <code>brooklyn</code>. (In real life, the hint comes from the email exchange.)
-  </div>
-</div>
-
 <section class="cs-foot">
   <div class="col col-narrow">
     <div style="font-family:var(--font-mono);font-size:11px;letter-spacing:0.14em;text-transform:uppercase;color:var(--fg-dim)">END OF CASE STUDY · NO. 03 (PUBLIC PORTION)</div>

--- a/work/hcai.html
+++ b/work/hcai.html
@@ -1,0 +1,460 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>designing for humans · raghav ahuja</title>
+<meta name="description" content="HCAI — a human-centered approach to AI integration. augmenting human capability, not replacing it.">
+<meta name="theme-color" content="#1a1814">
+<link rel="canonical" href="https://raghavahuja.com/work/hcai">
+<meta property="og:title" content="designing for humans · raghav ahuja">
+<meta property="og:description" content="human-centered AI. P.O.N.T.E. evaluation, augmentation over automation, six principles for ethical implementation.">
+<meta property="og:image" content="https://raghavahuja.com/og/hcai.png">
+<link rel="stylesheet" href="/colors_and_type.css">
+<link rel="stylesheet" href="/site.css">
+<link rel="stylesheet" href="/case-study.css">
+<link rel="stylesheet" href="/cmdk.css">
+<style>
+  /* ===== HCAI PAGE-SPECIFIC ===== */
+  .eyebrow {
+    font-family: var(--font-mono); font-size: 11px;
+    letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--heat); margin-bottom: var(--s-3);
+    font-weight: 600;
+  }
+  .lede-italic {
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-size: 22px; line-height: 1.45;
+    color: var(--fg-dim); max-width: 56ch;
+    margin: var(--s-3) 0 0;
+    font-weight: 300;
+  }
+
+  /* shift diagram — two circular models, side by side */
+  .shift {
+    margin: var(--s-5) 0 var(--s-4);
+    padding: clamp(24px, 4vw, 48px) clamp(16px, 3vw, 32px);
+    border: 1px solid var(--rule-strong);
+    background: var(--bg-deeper);
+  }
+  .shift-grid {
+    display: grid;
+    grid-template-columns: 1fr 60px 1fr;
+    gap: clamp(12px, 3vw, 36px);
+    align-items: center;
+  }
+  .model {
+    display: flex; flex-direction: column; align-items: center;
+    gap: 16px;
+  }
+  .model .label {
+    font-family: var(--font-mono); font-size: 10.5px;
+    letter-spacing: 0.16em; text-transform: uppercase;
+    color: var(--fg-faint);
+  }
+  .model .label.on { color: var(--heat); }
+  .orbit {
+    --size: clamp(180px, 24vw, 240px);
+    width: var(--size); height: var(--size);
+    position: relative;
+  }
+  .orbit::before {
+    content: ''; position: absolute; inset: 0;
+    border: 1px dashed var(--rule-strong);
+    border-radius: 50%;
+  }
+  .orbit .center {
+    position: absolute; top: 50%; left: 50%;
+    transform: translate(-50%, -50%);
+    width: 56px; height: 56px;
+    border-radius: 50%;
+    background: var(--bg);
+    border: 1px solid var(--rule-strong);
+    display: grid; place-items: center;
+    font-family: var(--font-mono); font-weight: 700;
+    font-size: 18px; letter-spacing: -0.02em;
+    color: var(--fg);
+  }
+  .orbit .node {
+    position: absolute;
+    width: 36px; height: 36px;
+    border-radius: 50%;
+    background: var(--bg-deeper);
+    border: 1px solid var(--rule-strong);
+    display: grid; place-items: center;
+    font-family: var(--font-mono); font-size: 13px; font-weight: 600;
+    color: var(--fg-dim);
+  }
+  .orbit .node.n1 { top: -6px; left: 50%; transform: translateX(-50%); }
+  .orbit .node.n2 { right: -6px; top: 50%; transform: translateY(-50%); }
+  .orbit .node.n3 { bottom: -6px; left: 50%; transform: translateX(-50%); }
+  .orbit .node.n4 { left: -6px; top: 50%; transform: translateY(-50%); }
+  /* HCAI variant — human at center is heat-colored, AI nodes muted */
+  .orbit.hcai .center { background: var(--heat); border-color: var(--heat); color: var(--fg-on-heat); }
+  .orbit.hcai .node { color: var(--fg-faint); }
+  /* Traditional variant — AI at center muted, humans surround */
+  .orbit.trad .center { color: var(--fg-faint); }
+  .orbit.trad .node { color: var(--fg); border-color: var(--rule-strong); }
+
+  .shift-arrow {
+    font-family: var(--font-mono); font-size: 28px;
+    color: var(--heat); text-align: center;
+    font-weight: 600;
+  }
+  .shift-cap {
+    margin-top: var(--s-4); padding-top: var(--s-3);
+    border-top: 1px solid var(--rule);
+    text-align: center;
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-size: 17px; line-height: 1.45; color: var(--fg-dim);
+    max-width: 56ch; margin-left: auto; margin-right: auto;
+  }
+  @media (max-width: 720px) {
+    .shift-grid { grid-template-columns: 1fr; }
+    .shift-arrow { transform: rotate(90deg); padding: 8px 0; }
+  }
+
+  /* P.O.N.T.E. cards — letter-led */
+  .ponte {
+    display: grid; grid-template-columns: 1fr;
+    gap: 0;
+    margin: var(--s-4) 0 var(--s-5);
+    border: 1px solid var(--rule);
+  }
+  .ponte-row {
+    display: grid;
+    grid-template-columns: 80px 1fr;
+    border-top: 1px solid var(--rule);
+  }
+  .ponte-row:first-child { border-top: 0; }
+  .ponte-row .letter {
+    background: var(--bg-deeper);
+    border-right: 1px solid var(--rule);
+    display: grid; place-items: center;
+    font-family: var(--font-mono);
+    font-size: clamp(38px, 5vw, 56px);
+    font-weight: 700; color: var(--heat);
+    letter-spacing: -0.04em;
+  }
+  .ponte-row .body {
+    padding: var(--s-3) var(--s-4);
+  }
+  .ponte-row .name {
+    font-family: var(--font-mono); font-size: 11px;
+    letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--fg-faint); margin-bottom: 4px;
+  }
+  .ponte-row .q {
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-size: 17px; color: var(--fg);
+    line-height: 1.4; margin: 0 0 8px;
+  }
+  .ponte-row .desc {
+    font-size: 14px; line-height: 1.6;
+    color: var(--fg-dim); margin: 0;
+  }
+  @media (max-width: 600px) {
+    .ponte-row { grid-template-columns: 56px 1fr; }
+    .ponte-row .letter { font-size: 30px; }
+  }
+
+  /* mini case-study card — google flights */
+  .cs-card {
+    margin: var(--s-4) 0 var(--s-5);
+    border: 1px solid var(--rule-strong);
+    background: var(--bg-deeper);
+    overflow: hidden;
+  }
+  .cs-card .h {
+    padding: 12px 18px;
+    border-bottom: 1px solid var(--rule);
+    font-family: var(--font-mono); font-size: 10.5px;
+    letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--fg-dim);
+    display: flex; justify-content: space-between;
+  }
+  .cs-card .h .src { color: var(--heat); }
+  .cs-card .b { padding: var(--s-4); }
+  .cs-card .b h4 {
+    margin: 0 0 var(--s-2); font-family: var(--font-mono);
+    font-size: 18px; font-weight: 600; letter-spacing: -0.02em;
+    color: var(--fg);
+  }
+  .cs-card .b p { margin: 0 0 var(--s-3); color: var(--fg-dim); font-size: 14.5px; line-height: 1.55; }
+  .cs-card .b p:last-child { margin-bottom: 0; }
+  .pp {
+    margin: var(--s-3) 0;
+    padding: 14px 18px;
+    background: var(--bg);
+    border: 1px solid var(--rule);
+    border-left: 3px solid var(--heat);
+    max-width: 460px;
+  }
+  .pp .pp-l {
+    font-family: var(--font-mono); font-size: 10px;
+    letter-spacing: 0.16em; text-transform: uppercase;
+    color: var(--heat); margin-bottom: 6px; font-weight: 600;
+  }
+  .pp .pp-h {
+    font-family: 'Fraunces', serif; font-weight: 600;
+    font-size: 18px; color: var(--fg);
+    margin-bottom: 4px;
+  }
+  .pp .pp-d {
+    font-size: 13.5px; color: var(--fg-dim); line-height: 1.5;
+  }
+
+  /* 6 principles */
+  .principles {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 0;
+    margin: var(--s-4) 0;
+    border: 1px solid var(--rule);
+  }
+  .principles > div {
+    padding: var(--s-3) var(--s-4);
+    border-right: 1px solid var(--rule);
+    border-bottom: 1px solid var(--rule);
+  }
+  .principles h4 {
+    margin: 0 0 6px;
+    font-family: var(--font-mono); font-size: 13px;
+    font-weight: 600; color: var(--heat);
+    letter-spacing: -0.005em;
+  }
+  .principles p {
+    margin: 0; font-size: 13.5px; line-height: 1.55;
+    color: var(--fg-dim);
+  }
+
+  /* closing quote */
+  .closing {
+    margin: var(--s-5) 0;
+    padding: var(--s-5) var(--s-4);
+    border-top: 1px solid var(--rule-strong);
+    border-bottom: 1px solid var(--rule-strong);
+    text-align: center;
+  }
+  .closing blockquote {
+    margin: 0; padding: 0; border: 0;
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-size: clamp(20px, 2.6vw, 28px); font-weight: 300;
+    line-height: 1.4; color: var(--fg);
+    max-width: 60ch; margin: 0 auto;
+  }
+  .closing .attr {
+    margin-top: var(--s-3);
+    font-family: var(--font-mono); font-size: 11px;
+    letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--fg-faint);
+  }
+</style>
+</head>
+<body>
+<div id="topbar-slot"></div>
+
+<section class="cs-hero">
+  <div class="col">
+    <div class="crumbs"><a href="/">home</a><span class="sep">/</span><a href="/work">work</a><span class="sep">/</span><span>designing for humans</span></div>
+    <div class="eyebrow">Research Framework</div>
+    <h1>designing for humans<span class="heat">.</span></h1>
+    <p class="deck">a human-centered approach to AI integration.</p>
+    <p class="lede-italic">Augmenting human capability, not replacing it.</p>
+    <div class="meta-row">
+      <span><span class="dot">●</span> FRAMEWORK · 03B · 2024 HCAI</span>
+      <span>STATUS: LIVE</span>
+      <span>SIBLING OF /work/mind</span>
+    </div>
+  </div>
+</section>
+
+<section class="chapter">
+  <div class="col col-narrow prose">
+    <div class="chapter-num">01 — CORE PHILOSOPHY</div>
+    <h2>humans in the group; computers in the loop.</h2>
+    <p>Instead of viewing AI as a replacement for human labor, Human-Centered AI emphasizes AI as a tool for augmenting human capabilities. The shift is small in language and large in everything that follows.</p>
+
+    <div class="shift">
+      <div class="shift-grid">
+        <div class="model">
+          <div class="label">Traditional Model</div>
+          <div class="orbit trad">
+            <div class="center">AI</div>
+            <div class="node n1">H</div>
+            <div class="node n2">H</div>
+            <div class="node n3">H</div>
+            <div class="node n4">H</div>
+          </div>
+          <div class="label">AI at center · humans orbit</div>
+        </div>
+        <div class="shift-arrow">→</div>
+        <div class="model">
+          <div class="label on">HCAI Model</div>
+          <div class="orbit hcai">
+            <div class="center">H</div>
+            <div class="node n1">AI</div>
+            <div class="node n2">AI</div>
+            <div class="node n3">AI</div>
+            <div class="node n4">AI</div>
+          </div>
+          <div class="label on">human at center · AI orbits</div>
+        </div>
+      </div>
+      <div class="shift-cap">"Non-deterministic systems require a human-centered buffer against unpredictability."</div>
+    </div>
+  </div>
+</section>
+
+<section class="chapter">
+  <div class="col col-narrow prose">
+    <div class="chapter-num">02 — THE P.O.N.T.E. EVALUATION FRAMEWORK</div>
+    <h2>does AI add unique value?</h2>
+    <p>A step-by-step model for deciding whether AI belongs in the surface at all. The honest answer is sometimes no — and the rubric is most useful in the moments when the team wants the answer to be yes.</p>
+
+    <div class="ponte">
+      <div class="ponte-row">
+        <div class="letter">P</div>
+        <div class="body">
+          <div class="name">Patterns</div>
+          <p class="q">"Is there a user need and an identifiable pattern of behavior?"</p>
+          <p class="desc">What are the common issues users encounter? Can these be traced to identifiable patterns? Is there data supporting them?</p>
+        </div>
+      </div>
+      <div class="ponte-row">
+        <div class="letter">O</div>
+        <div class="body">
+          <div class="name">Outcome</div>
+          <p class="q">"What is the definition of success?"</p>
+          <p class="desc">What metrics will indicate success? What OKRs will this impact? How is user satisfaction measured?</p>
+        </div>
+      </div>
+      <div class="ponte-row">
+        <div class="letter">N</div>
+        <div class="body">
+          <div class="name">Need</div>
+          <p class="q">"Can a non-AI solution work better?"</p>
+          <p class="desc">What were the limitations with traditional systems? Does AI offer something unique? Or does the solution feel over-engineered?</p>
+        </div>
+      </div>
+      <div class="ponte-row">
+        <div class="letter">T</div>
+        <div class="body">
+          <div class="name">Type</div>
+          <p class="q">"Automation (speed) or augmentation (creativity)?"</p>
+          <p class="desc">Automation replaces human tasks. Augmentation assists humans with tasks they already do, making them better at their jobs.</p>
+        </div>
+      </div>
+      <div class="ponte-row">
+        <div class="letter">E</div>
+        <div class="body">
+          <div class="name">Equity</div>
+          <p class="q">"How do we ensure fairness and reduce bias?"</p>
+          <p class="desc">A tour-suggestion AI should not keep recommending one specific tour and never others. Bias in input becomes bias in output, at scale.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="chapter">
+  <div class="col col-narrow prose">
+    <div class="chapter-num">03 — CASE STUDY · PRICE PREDICTIONS</div>
+    <h2>the AI predicts. the human decides.</h2>
+    <p>How Google Flights uses HCAI to augment, not replace, human decision-making — and why it's the pattern most travel surfaces should be copying.</p>
+
+    <div class="cs-card">
+      <div class="h">
+        <span>EXAMPLE · GOOGLE FLIGHTS</span>
+        <span class="src">DECISION PARALYSIS</span>
+      </div>
+      <div class="b">
+        <h4>The problem</h4>
+        <p>Travelers repeatedly re-check prices, unsure if they're getting the best deal. The anxiety of "what if it gets cheaper?" creates hesitation loops — refreshing the same query, abandoning the cart, returning two days later.</p>
+
+        <h4>The HCAI solution</h4>
+        <p>A small price-confidence card that surfaces a prediction and gets out of the way:</p>
+
+        <div class="pp">
+          <div class="pp-l">PRICE INSIGHT</div>
+          <div class="pp-h">Lower than usual.</div>
+          <div class="pp-d">Prices are currently low for your dates.</div>
+        </div>
+
+        <p>The AI provides a prediction. The human retains full control of the decision.</p>
+
+        <h4>Key takeaway</h4>
+        <p>The AI predicts; the human decides. Augmentation over automation. The same pattern is portable to any high-anxiety commerce moment — insurance add-ons, travel-protection upsells, return windows.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="chapter">
+  <div class="col col-narrow prose">
+    <div class="chapter-num">04 — PRINCIPLES</div>
+    <h2>six guardrails.</h2>
+    <p>Ethical guardrails for responsible AI implementation. These are not obstacles to design — they're the conditions under which design earns user trust over time.</p>
+
+    <div class="principles">
+      <div>
+        <h4>Transparency</h4>
+        <p>Explain why the AI made the suggestion. Clear reasoning for decisions and actions.</p>
+      </div>
+      <div>
+        <h4>Accountability</h4>
+        <p>Clear lines of responsibility for AI errors. Organizations stay accountable for impact.</p>
+      </div>
+      <div>
+        <h4>Privacy</h4>
+        <p>Data used ethically and with consent. Strict adherence to privacy standards.</p>
+      </div>
+      <div>
+        <h4>Human Autonomy</h4>
+        <p>Empower users by enhancing abilities. Provide control over AI-assisted processes.</p>
+      </div>
+      <div>
+        <h4>Beneficence</h4>
+        <p>Aim to benefit individuals and society. Actively improve well-being; avoid harm.</p>
+      </div>
+      <div>
+        <h4>Accessibility</h4>
+        <p>Intuitive, user-friendly interfaces that cater to varying abilities and backgrounds.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="chapter">
+  <div class="col col-narrow prose">
+    <div class="closing">
+      <blockquote>"Our goal is not to have or use AI but to ensure we all understand it as a tool for solving our problems."</blockquote>
+      <div class="attr">— THE HCAI PRINCIPLE</div>
+    </div>
+
+    <div class="aside">
+      <span class="label">A NOTE ON ORIGIN</span>
+      Designing for Humans is the research framework I authored at EF World Journeys for evaluating where AI belongs in the booking surface. This page documents the conceptual layer; implementation details are available on request.
+    </div>
+  </div>
+</section>
+
+<section class="cs-foot">
+  <div class="col col-narrow">
+    <div style="font-family:var(--font-mono);font-size:11px;letter-spacing:0.14em;text-transform:uppercase;color:var(--fg-dim)">END · FRAMEWORK 03B</div>
+    <div class="next-up">
+      <a href="/work/mind" class="nx">
+        <div class="label">SIBLING — FRAMEWORK 03A</div>
+        <div class="title">MIND framework →</div>
+      </a>
+      <a href="/work/ef" class="nx">
+        <div class="label">↩ CASE STUDY · 03</div>
+        <div class="title">EF world journeys</div>
+      </a>
+    </div>
+  </div>
+</section>
+
+<script src="/site.js"></script>
+</body>
+</html>

--- a/work/index.html
+++ b/work/index.html
@@ -4,11 +4,11 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>work — raghav ahuja</title>
-<meta name="description" content="eleven years of design engineering. case studies, frameworks, and the things i'm allowed to talk about.">
+<meta name="description" content="fifteen years of design engineering. case studies, frameworks, and the things i'm allowed to talk about.">
 <meta name="theme-color" content="#1a1814">
 <link rel="canonical" href="https://raghavahuja.com/work">
 <meta property="og:title" content="work — raghav ahuja">
-<meta property="og:description" content="eleven years of design engineering. case studies, frameworks, and the things i'm allowed to talk about.">
+<meta property="og:description" content="fifteen years of design engineering. case studies, frameworks, and the things i'm allowed to talk about.">
 <meta property="og:image" content="https://raghavahuja.com/og.png">
 <link rel="stylesheet" href="/colors_and_type.css">
 <link rel="stylesheet" href="/site.css">
@@ -59,7 +59,7 @@
   <div class="col">
     <div class="crumbs"><a href="/">home</a><span class="sep">/</span><span>work</span></div>
     <h1>work.</h1>
-    <p class="lede">eleven years of design engineering. a few things i'm allowed to talk about. the rest you'll have to email me for.</p>
+    <p class="lede">fifteen years of design engineering. a few things i'm allowed to talk about. the rest you'll have to email me for.</p>
     <p class="lede dim">written long. read what you need.</p>
   </div>
 </section>
@@ -67,10 +67,10 @@
 <section class="wlist">
   <div class="col">
     <div class="filterbar">
-      <span class="on">ALL · 7</span>
-      <span>SHIPPED · 4</span>
+      <span class="on">ALL · 4</span>
+      <span>SHIPPED · 2</span>
       <span>GATED · 1</span>
-      <span>ARCHIVED · 2</span>
+      <span>ARCHIVED · 1</span>
       <span class="grow">SORTED BY YEAR ↓</span>
     </div>
 
@@ -122,17 +122,6 @@
       <span class="arrow">→</span>
     </a>
 
-    <a href="/work/social-booth" class="wrow">
-      <span class="num">005</span>
-      <span class="wm">2016–20 · CD</span>
-      <div>
-        <div class="wt">the social booth</div>
-        <div class="wd">creative director, mumbai. scaled team 1→10+. ducati +500% online sales. audi. 20+ APAC clients.</div>
-      </div>
-      <span class="wm">BRAND · CAMPAIGN</span>
-      <span class="ws archived">ARCHIVED</span>
-      <span class="arrow">→</span>
-    </a>
   </div>
 </section>
 

--- a/work/jmnpr.html
+++ b/work/jmnpr.html
@@ -259,7 +259,7 @@
 </div>
 
 <div class="col col-narrow prose">
-  <p><strong>JMNPR Labs is a one-person studio</strong> I started in my evenings, after thirteen years of shipping inside other people's roadmaps. The thesis is narrow and the catalog is broad: production-grade, self-serve tools for the creators and craftspeople the category has under-served. One brand. Many verticals. Honest pricing. No sales motion.</p>
+  <p><strong>JMNPR Labs is a one-person studio</strong> I started in my evenings, after fifteen years of shipping inside other people's roadmaps. The thesis is narrow and the catalog is broad: production-grade, self-serve tools for the creators and craftspeople the category has under-served. One brand. Many verticals. Honest pricing. No sales motion.</p>
 
   <p>Arqo is one expression of the studio — the consumer surface. This case study is about everything else. What's live, what's on deck, and the architectural bet underneath the whole thing: that a single solo operator, with AI-native tooling and fifteen years of accumulated taste, can now ship the kind of product catalog that previously required a twelve-person company.</p>
 

--- a/work/mind.html
+++ b/work/mind.html
@@ -1,0 +1,419 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MIND framework · raghav ahuja</title>
+<meta name="description" content="MIND — a behavioral operating system. quantifying user hesitation; deploying interface patterns to resolve it.">
+<meta name="theme-color" content="#1a1814">
+<link rel="canonical" href="https://raghavahuja.com/work/mind">
+<meta property="og:title" content="MIND framework · raghav ahuja">
+<meta property="og:description" content="behavioral operating system. CtB, the 5 pillars, the BDI, and the ethical ethos.">
+<meta property="og:image" content="https://raghavahuja.com/og/mind.png">
+<link rel="stylesheet" href="/colors_and_type.css">
+<link rel="stylesheet" href="/site.css">
+<link rel="stylesheet" href="/case-study.css">
+<link rel="stylesheet" href="/cmdk.css">
+<style>
+  /* ===== MIND PAGE-SPECIFIC ===== */
+  .eyebrow {
+    font-family: var(--font-mono); font-size: 11px;
+    letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--heat); margin-bottom: var(--s-3);
+    font-weight: 600;
+  }
+  .lede-italic {
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-size: 22px; line-height: 1.45;
+    color: var(--fg-dim); max-width: 56ch;
+    margin: var(--s-4) 0 var(--s-5);
+    font-weight: 300;
+  }
+
+  /* CtB equation block */
+  .eq {
+    margin: var(--s-5) 0 var(--s-4);
+    padding: clamp(20px, 3vw, 36px) clamp(20px, 3vw, 32px);
+    border: 1px solid var(--rule-strong);
+    background: var(--bg-deeper);
+    text-align: center;
+    overflow-x: auto;
+  }
+  .eq .formula {
+    font-family: var(--font-mono);
+    font-size: clamp(20px, 3.4vw, 30px);
+    font-weight: 600; letter-spacing: -0.01em;
+    color: var(--fg);
+    line-height: 1.4;
+  }
+  .eq .formula .heat { color: var(--heat); }
+  .eq .formula .dim { color: var(--fg-faint); }
+  .eq .cap {
+    margin-top: var(--s-3);
+    font-family: var(--font-mono); font-size: 11px;
+    letter-spacing: 0.08em; color: var(--fg-faint);
+    text-transform: uppercase;
+  }
+  .eq .cap em { color: var(--fg-dim); font-style: italic; text-transform: none; }
+
+  /* force / pillar grid */
+  .grid-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: var(--s-3);
+    margin: var(--s-4) 0 var(--s-5);
+  }
+  .gc {
+    padding: var(--s-4);
+    border: 1px solid var(--rule);
+    background: var(--bg-deeper);
+    display: flex; flex-direction: column; gap: 10px;
+  }
+  .gc .num {
+    font-family: var(--font-mono); font-size: 10.5px;
+    letter-spacing: 0.14em; color: var(--heat);
+  }
+  .gc .name {
+    font-family: var(--font-mono); font-size: 18px;
+    font-weight: 600; letter-spacing: -0.02em;
+    color: var(--fg);
+  }
+  .gc .q {
+    font-family: 'Fraunces', serif; font-style: italic;
+    font-size: 14.5px; color: var(--fg-dim);
+    line-height: 1.45;
+  }
+  .gc .body {
+    font-size: 14px; line-height: 1.55;
+    color: var(--fg-dim);
+  }
+  .gc .body strong { color: var(--fg); font-weight: 600; }
+  .gc .patterns {
+    margin-top: auto;
+    padding-top: 10px;
+    border-top: 1px dashed var(--rule);
+    font-family: var(--font-mono); font-size: 10.5px;
+    letter-spacing: 0.06em; color: var(--fg-faint);
+    line-height: 1.5;
+  }
+
+  /* BDI diagnostic card */
+  .bdi-card {
+    margin: var(--s-4) 0;
+    border: 1px solid var(--rule-strong);
+    background: var(--bg-deeper);
+  }
+  .bdi-card .h {
+    padding: 12px 18px;
+    border-bottom: 1px solid var(--rule);
+    display: flex; justify-content: space-between; align-items: baseline;
+    font-family: var(--font-mono); font-size: 10.5px;
+    letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--fg-dim);
+  }
+  .bdi-card .h .risk { color: var(--heat); font-weight: 700; }
+  .bdi-card .b { padding: 18px; }
+  .bdi-card .b .row {
+    display: grid; grid-template-columns: 110px 1fr;
+    gap: 14px; padding: 9px 0;
+    border-top: 1px solid var(--rule);
+    font-size: 14px; line-height: 1.5;
+  }
+  .bdi-card .b .row:first-child { border-top: 0; }
+  .bdi-card .b .row .k {
+    font-family: var(--font-mono); font-size: 10.5px;
+    letter-spacing: 0.1em; text-transform: uppercase;
+    color: var(--fg-faint);
+    padding-top: 3px;
+  }
+  .bdi-card .b .row .v { color: var(--fg); }
+  .bdi-card .b .row .v.score {
+    font-family: var(--font-mono); font-weight: 700;
+    color: var(--heat); font-size: 22px; letter-spacing: -0.02em;
+  }
+  .bdi-card .b .row .v em { color: var(--fg-dim); font-style: italic; }
+
+  /* score legend */
+  .legend {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0;
+    margin: var(--s-3) 0 var(--s-4);
+    border: 1px solid var(--rule);
+  }
+  .legend > div {
+    padding: 14px 16px;
+    border-right: 1px solid var(--rule);
+  }
+  .legend > div:last-child { border-right: 0; }
+  .legend .band {
+    font-family: var(--font-mono); font-size: 11px;
+    letter-spacing: 0.12em; font-weight: 700;
+    margin-bottom: 4px;
+  }
+  .legend .band.good { color: var(--heat); }
+  .legend .band.mid { color: var(--fg); }
+  .legend .band.bad { color: var(--fg-dim); }
+  .legend .desc {
+    font-size: 13px; color: var(--fg-dim); line-height: 1.5;
+  }
+  @media (max-width: 700px) {
+    .legend { grid-template-columns: 1fr; }
+    .legend > div { border-right: 0; border-bottom: 1px solid var(--rule); }
+    .legend > div:last-child { border-bottom: 0; }
+  }
+
+  /* ethos quad */
+  .ethos {
+    display: grid; grid-template-columns: 1fr 1fr;
+    gap: 0; margin: var(--s-4) 0;
+    border: 1px solid var(--rule);
+  }
+  .ethos > div {
+    padding: var(--s-4);
+    border-right: 1px solid var(--rule);
+    border-bottom: 1px solid var(--rule);
+  }
+  .ethos > div:nth-child(2n) { border-right: 0; }
+  .ethos > div:nth-last-child(-n+2) { border-bottom: 0; }
+  .ethos h4 {
+    margin: 0 0 8px;
+    font-family: var(--font-mono); font-size: 13px;
+    font-weight: 600; letter-spacing: -0.005em;
+    color: var(--heat);
+  }
+  .ethos p {
+    margin: 0; font-size: 14px; line-height: 1.55;
+    color: var(--fg-dim);
+  }
+  @media (max-width: 700px) {
+    .ethos { grid-template-columns: 1fr; }
+    .ethos > div { border-right: 0; }
+  }
+</style>
+</head>
+<body>
+<div id="topbar-slot"></div>
+
+<section class="cs-hero">
+  <div class="col">
+    <div class="crumbs"><a href="/">home</a><span class="sep">/</span><a href="/work">work</a><span class="sep">/</span><span>MIND</span></div>
+    <div class="eyebrow">Behavioral Framework</div>
+    <h1>MIND<span class="heat">.</span></h1>
+    <p class="deck">a behavioral operating system. turning uncertainty into confident decisions — quantifying user hesitation and dynamically deploying interface patterns to resolve it.</p>
+    <div class="meta-row">
+      <span><span class="dot">●</span> FRAMEWORK · 03A · 2024 BEHAVIORAL</span>
+      <span>STATUS: LIVE</span>
+      <span>SIBLING OF /work/hcai</span>
+    </div>
+  </div>
+</section>
+
+<div class="col col-narrow prose">
+  <div class="eq">
+    <div class="formula">CtB = (Clarity + Trust + Motivation) <span class="heat">−</span> (Friction <span class="heat">×</span> 2) <span class="heat">−</span> Risk</div>
+    <div class="cap">CONFIDENCE-TO-BOOK · <em>quantifies a user's readiness to commit</em></div>
+  </div>
+  <p>Friction carries 2× negative weight. That's the core insight — and the reason the formula doesn't reduce to "add more clarity." A clean checkout with a forgivable price still loses to a confusing one with a great deal, because the friction tax compounds at every step.</p>
+</div>
+
+<section class="chapter">
+  <div class="col col-narrow prose">
+    <div class="chapter-num">01 — THE PHYSICS OF DECISION MAKING</div>
+    <h2>three forces.</h2>
+    <p>The framework operationalizes three fundamental psychological forces. None of them are new — they're inherited from forty years of behavioral economics. What's new is encoding them as design tokens you can tune.</p>
+    <!-- TODO: add 4th force — original brief promised four; only three were carried over. -->
+
+    <div class="grid-cards">
+      <div class="gc">
+        <div class="num">01</div>
+        <div class="name">Cognitive Efficiency</div>
+        <div class="body">Humans are cognitive misers. We gravitate toward defaults, simple comparisons, and pre-curated options.</div>
+        <div class="patterns"><strong style="color:var(--fg)">DESIGN IMPLICATION</strong><br>Curate the path. Don't just provide choices.</div>
+      </div>
+      <div class="gc">
+        <div class="num">02</div>
+        <div class="name">Loss Aversion</div>
+        <div class="body">Fear of loss is 2–3× more powerful than the desire for gain. The pain of losing outweighs the pleasure of gaining.</div>
+        <div class="patterns"><strong style="color:var(--fg)">DESIGN IMPLICATION</strong><br>Frame around avoiding missed opportunities.</div>
+      </div>
+      <div class="gc">
+        <div class="num">03</div>
+        <div class="name">Social Orientation</div>
+        <div class="body">In moments of uncertainty, humans look to the herd. Social proof resolves ambiguity faster than argument does.</div>
+        <div class="patterns"><strong style="color:var(--fg)">DESIGN IMPLICATION</strong><br>Social proof at the exact moment of hesitation.</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="chapter">
+  <div class="col col-narrow prose">
+    <div class="chapter-num">02 — THE 5 PILLARS OF INFLUENCE</div>
+    <h2>five questions.</h2>
+    <p>Every pillar addresses a question the user is silently asking. Walk a funnel and listen for the one that isn't being answered — that's where the leak is.</p>
+
+    <div class="grid-cards">
+      <div class="gc">
+        <div class="num">01 · ORIENTATION</div>
+        <div class="q">"Do I understand what this is and why it matters?"</div>
+        <div class="patterns">Clarity Headers · Context Frames · Pricing Anchors · Feature Grids</div>
+      </div>
+      <div class="gc">
+        <div class="num">02 · MOTIVATION</div>
+        <div class="q">"Do I want this?"</div>
+        <div class="patterns">Dynamic Social Proof · Scarcity Signals · Value Highlights · Emotional Content</div>
+      </div>
+      <div class="gc">
+        <div class="num">03 · DECISION ARCHITECTURE</div>
+        <div class="q">"Is this choice easy?"</div>
+        <div class="patterns">Smart Defaults · Comparison Grids · Best-Value Labels · Progressive Commitment</div>
+      </div>
+      <div class="gc">
+        <div class="num">04 · TRUST &amp; REASSURANCE</div>
+        <div class="q">"Do I feel safe committing?"</div>
+        <div class="patterns">Risk-Reversal Guarantees · Transparency Blocks · Review Panels · Authority Signals</div>
+      </div>
+      <div class="gc">
+        <div class="num">05 · ACTION</div>
+        <div class="q">"Is now the right moment to act?"</div>
+        <div class="patterns">Verb-First CTAs · Momentum Locks · Micro-Reassurance · Progress Indicators</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="chapter">
+  <div class="col col-narrow prose">
+    <div class="chapter-num">03 — CODIFIED INTO TOKENS</div>
+    <h2>behavior as a token.</h2>
+    <p>The framework only works if it's not a slide deck. These tokens let developers adjust psychological intensity programmatically — same surface, different funnel depths get different tunings, and the design system stays the source of truth.</p>
+
+<pre><code>// Behavioral Token Definitions
+// Adjust psychological intensity programmatically.
+
+type UrgencyLevel = "high" | "medium" | "low";
+type TrustLevel   = "verified_partner" | "standard";
+type PriceAnchor  = "strike_through" | "comparative";
+type CTAFraming   = "commit" | "risk_free" | "soft_save";
+
+interface BehavioralTokens {
+  // Color intensity + copy phrasing for scarcity
+  "behavioral.urgency": UrgencyLevel;
+
+  // Prominence of validation signals
+  "behavioral.socialproof": 1 | 2 | 3 | 4;
+
+  // Visual weight of guarantees by funnel depth
+  "behavioral.trust": TrustLevel;
+
+  // How value context is displayed
+  "behavioral.price.anchor": PriceAnchor;
+
+  // Linguistic framing of action buttons
+  "behavioral.cta.framing": CTAFraming;
+}
+
+// Example: high-stakes checkout step
+const checkoutTokens: BehavioralTokens = {
+  "behavioral.urgency":      "high",
+  "behavioral.socialproof":  4,
+  "behavioral.trust":        "verified_partner",
+  "behavioral.price.anchor": "strike_through",
+  "behavioral.cta.framing":  "risk_free",
+};</code></pre>
+  </div>
+</section>
+
+<section class="chapter">
+  <div class="col col-narrow prose">
+    <div class="chapter-num">04 — BEHAVIORAL DROP-OFF INDEX</div>
+    <h2>where the chain breaks.</h2>
+    <p>BDI scores every step of a funnel against the four levers that move CtB. A leaking funnel is rarely all leaking — usually it's one step doing damage. The score finds the step.</p>
+
+    <div class="eq">
+      <div class="formula">BDI(step) = <span class="dim">(</span>Alignment + Motivation + Trust + (5 <span class="heat">−</span> Friction)<span class="dim">)</span> <span class="heat">/</span> 4</div>
+      <div class="cap">PER-STEP DIAGNOSTIC · <em>0 to 5, higher is healthier</em></div>
+    </div>
+
+    <h3>reading the score</h3>
+    <div class="legend">
+      <div>
+        <div class="band good">BDI ≥ 4.0</div>
+        <div class="desc">Strong alignment, low resistance. Don't redesign — instrument.</div>
+      </div>
+      <div>
+        <div class="band mid">BDI 2.5 – 4.0</div>
+        <div class="desc">Optimization opportunity. The pillars to lift are visible in the sub-scores.</div>
+      </div>
+      <div>
+        <div class="band bad">BDI ≤ 2.5</div>
+        <div class="desc">Behavioral leak, high abandon risk. Treat as a P0.</div>
+      </div>
+    </div>
+
+    <h3>diagnostic example</h3>
+    <div class="bdi-card">
+      <div class="h">
+        <span>STEP · CHECKOUT</span>
+        <span class="risk">HIGH RISK</span>
+      </div>
+      <div class="b">
+        <div class="row"><span class="k">BDI Score</span><span class="v score">2.4</span></div>
+        <div class="row"><span class="k">Diagnosis</span><span class="v"><strong>Trust Leak.</strong> User reached payment but exited. Hover maps show hesitation on policy text. <em>(Trust = 1.6, Friction = 4.2.)</em></span></div>
+        <div class="row"><span class="k">Rx</span><span class="v">Surface guarantees. Add "Reserve Risk-Free" microcopy. Ensure total price transparency above the CTA.</span></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="chapter">
+  <div class="col col-narrow prose">
+    <div class="chapter-num">05 — THE ETHICAL ETHOS</div>
+    <h2>four non-negotiables.</h2>
+    <p>Ethics is not a constraint on behavioral design — it's a performance multiplier. Pressure tactics and false urgency lift conversion this quarter and tax retention every quarter after. The framework refuses them by construction.</p>
+
+    <div class="ethos">
+      <div>
+        <h4>Clarity over Persuasion</h4>
+        <p>Users must understand the choice and its consequences. A confused yes is not a yes worth having.</p>
+      </div>
+      <div>
+        <h4>Confidence over Pressure</h4>
+        <p>Nudge toward certainty; reject false urgency. If the timer wouldn't be there with the customer in the room, don't put it on the screen.</p>
+      </div>
+      <div>
+        <h4>Momentum over Friction</h4>
+        <p>Accelerate through smart defaults, not dark patterns. Removing a click is design. Hiding a checkbox is not.</p>
+      </div>
+      <div>
+        <h4>Integrity over Manipulation</h4>
+        <p>Scarcity, social proof, and data must be real. If the "12 people viewing" is fake, the whole framework is fake.</p>
+      </div>
+    </div>
+
+    <div class="aside">
+      <span class="label">A NOTE ON THE NAME</span>
+      MIND — Motivational Interface &amp; Nudge Design. The full framework is documented internally; this is the public conceptual layer. Implementation details are available on request.
+    </div>
+  </div>
+</section>
+
+<section class="cs-foot">
+  <div class="col col-narrow">
+    <div style="font-family:var(--font-mono);font-size:11px;letter-spacing:0.14em;text-transform:uppercase;color:var(--fg-dim)">END · FRAMEWORK 03A</div>
+    <div class="next-up">
+      <a href="/work/hcai" class="nx">
+        <div class="label">SIBLING — FRAMEWORK 03B</div>
+        <div class="title">designing for humans →</div>
+      </a>
+      <a href="/work/ef" class="nx">
+        <div class="label">↩ CASE STUDY · 03</div>
+        <div class="title">EF world journeys</div>
+      </a>
+    </div>
+  </div>
+</section>
+
+<script src="/site.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Surgical cleanup pass across the site. Seven small tickets, no refactors outside scope.

- **T-01** — Removed the visible password-hint block on `/work/ef` that was leaking the gate password (`brooklyn`) to anyone loading the page.
- **T-02** — Created `/work/mind` and `/work/hcai` framework pages from the old portfolio briefs. Built in the current site's voice/tokens (case-study primitives + CSS-rendered diagrams), not the old framer-motion + zinc-950 stack. Sibling cross-links wired both directions; references from `/work/ef` and `/about` now resolve.
- **T-03** — Removed the Social Booth card from `/work` index. Prose mention on `/about` left intact (was already plain text, no hyperlink to strip). No other code references the route.
- **T-04** — Updated `/work` header pill counts: `ALL · 4 · SHIPPED · 2 · GATED · 1 · ARCHIVED · 1`.
- **T-05** — Normalized career-length claims to "fifteen years" — three locations on `/work` index, one on `/work/jmnpr`. Other "year" mentions (Final Draft "thirty years", FDX "20 years", arqo dialog) are about competitors/category/dialog and were left alone.
- **T-06** — Fixed the mamdani mapper footer link to point at the canonical `/receipts/mamdani-mapper`. Vercel redirects from the stale `.html` and `?slug=` URLs already exist in `vercel.json`, so no redirect-config change was needed.
- **T-07** — Added a hand-curated "updated 2026·05·06" stamp to the homepage NOW block. Format matches the existing `YYYY·MM·DD` convention used by the receipts cards. The date is a single inline string at `index.html:461` — edit-by-hand, not auto-generated.

Sitemap updated with the two new framework routes.

## Decisions worth flagging

- **`brooklyn` still in JS source.** The visible hint is gone, but `const PW = 'brooklyn'` remains in `work/ef.html`. Out of scope per "delete the entire PASSWORD HINT block. Nothing else on the page changes." Worth a follow-up to either rotate the password or move to a hashed check (the `scripts/encrypt-case.mjs` already in the repo suggests this was the intended path).
- **MIND "four forces" gap.** The original brief promised four psychological forces but only listed three. Shipped three with a `// TODO` HTML comment in `work/mind.html` so the gap is findable.
- **No raster diagrams.** The 6 framework images referenced in the old portfolio (`mind-bdi-heatmap.png` etc.) don't live in this repo. Built every diagram as CSS art, matching the existing `.ef-mock` / `.jm-mock` pattern.

## Test plan

- [ ] `/work/ef` no longer shows the password hint and no longer says "PASSWORD HINT" anywhere visible
- [ ] `/work/mind` returns 200 and renders cleanly (CtB equation, three forces, 5 pillars, behavioral tokens, BDI, ethos)
- [ ] `/work/hcai` returns 200 and renders cleanly (shift diagram, P.O.N.T.E. table, Google Flights mini-card, six principles, closing quote)
- [ ] EF case study footer links to MIND + HCAI both resolve
- [ ] `/about` MIND + HCAI links both resolve
- [ ] `/work` shows 4 cards (no Social Booth) with correct header counts
- [ ] All "career length" mentions read "fifteen years"; competitor/category mentions untouched
- [ ] Mamdani mapper footer link goes to `/receipts/mamdani-mapper`
- [ ] Homepage NOW block shows "updated 2026·05·06" stamp adjacent to the label

🤖 Generated with [Claude Code](https://claude.com/claude-code)