### PR TITLE
work: add social booth case study (RAG-4)

### DIFF
--- a/work/social-booth.html
+++ b/work/social-booth.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>social booth — case study · raghav ahuja</title>
+<meta name="description" content="social booth — foundational creative / head of design, 2016–2020. built design from 0 → 8+, led campaign creative for ford india, ducati india, and the wendy's india launch. acquired by vaynermedia 2023.">
+<meta name="theme-color" content="#1a1814">
+<link rel="canonical" href="https://raghavahuja.com/work/social-booth">
+<meta property="og:title" content="social booth — case study · raghav ahuja">
+<meta property="og:description" content="foundational creative / head of design, 2016–2020. built design from 0 → 8+, led campaign creative for ford india, ducati india, and the wendy's india launch.">
+<meta property="og:image" content="https://raghavahuja.com/og.png">
+<link rel="stylesheet" href="/colors_and_type.css">
+<link rel="stylesheet" href="/site.css">
+<link rel="stylesheet" href="/case-study.css">
+<link rel="stylesheet" href="/cmdk.css">
+<style>
+  /* ===== SOCIAL BOOTH — BRAND-WORK PLACEHOLDER GRID ===== */
+  .sb-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--s-4);
+    margin: var(--s-5) 0 var(--s-6);
+  }
+  @media (max-width: 880px) {
+    .sb-grid { grid-template-columns: 1fr; }
+  }
+  .sb-tile {
+    border: 1px solid var(--rule);
+    background: var(--bg-deeper);
+    aspect-ratio: 4 / 3;
+    display: flex; flex-direction: column;
+    justify-content: space-between;
+    padding: var(--s-3) var(--s-4);
+    position: relative;
+    overflow: hidden;
+  }
+  .sb-tile::before {
+    content: '';
+    position: absolute; inset: 0;
+    background:
+      repeating-linear-gradient(
+        135deg,
+        transparent 0 14px,
+        rgba(255,255,255,0.02) 14px 15px
+      );
+    pointer-events: none;
+  }
+  .sb-tile .sb-num {
+    font-family: var(--font-mono); font-size: 11px;
+    letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--fg-faint);
+    position: relative;
+  }
+  .sb-tile .sb-brand {
+    font-family: var(--font-mono);
+    font-size: clamp(22px, 3vw, 32px);
+    font-weight: 700; letter-spacing: -0.03em;
+    color: var(--fg);
+    line-height: 1;
+    position: relative;
+  }
+  .sb-tile .sb-cap {
+    font-family: var(--font-mono); font-size: 10.5px;
+    letter-spacing: 0.1em; text-transform: uppercase;
+    color: var(--fg-dim);
+    position: relative;
+  }
+  .sb-cap-row {
+    margin-top: var(--s-3);
+    font-family: var(--font-mono); font-size: 11px;
+    color: var(--fg-faint); letter-spacing: 0.08em;
+    text-transform: uppercase; text-align: center;
+  }
+  .sb-cap-row em { color: var(--fg-dim); font-style: italic; text-transform: none; }
+
+  /* numbered list inside chapters */
+  .sb-list {
+    list-style: none; padding: 0; margin: var(--s-4) 0 var(--s-5);
+  }
+  .sb-list li {
+    padding: var(--s-4) 0;
+    border-top: 1px solid var(--rule);
+  }
+  .sb-list li:last-child { border-bottom: 1px solid var(--rule); }
+  .sb-list .sb-tag {
+    font-family: var(--font-mono); font-size: 11px;
+    letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--heat); margin-bottom: 8px;
+  }
+  .sb-list .sb-tag .n { color: var(--fg-faint); margin-right: 10px; }
+  .sb-list .sb-body {
+    font-size: 15.5px; line-height: 1.6; color: var(--fg);
+    max-width: 62ch;
+  }
+</style>
+</head>
+<body>
+<div id="topbar-slot"></div>
+
+<section class="cs-hero">
+  <div class="col">
+    <div class="crumbs"><a href="/">home</a><span class="sep">/</span><a href="/work">work</a><span class="sep">/</span><span>social booth</span></div>
+    <h1>SOCIAL BOOTH<span class="heat">.</span></h1>
+    <p class="deck">foundational creative / head of design · 2016–2020. built and led the design team from zero to 8+. led campaign creative for ford india, ducati india, and the wendy's india launch. acquired by vaynermedia 2023.</p>
+    <div class="meta-row">
+      <span><span class="dot">●</span> CASE STUDY · SOCIAL BOOTH · 2016–2020</span>
+      <span>FOUNDATIONAL CREATIVE / HEAD OF DESIGN</span>
+      <span>STATUS: ARCHIVED</span>
+    </div>
+  </div>
+</section>
+
+<div class="col">
+  <div class="sb-grid">
+    <!-- TODO: real brand work assets -->
+    <div class="sb-tile">
+      <div class="sb-num">01</div>
+      <div class="sb-brand">FORD INDIA</div>
+      <div class="sb-cap">CAMPAIGN CREATIVE · 2017–19</div>
+    </div>
+    <div class="sb-tile">
+      <div class="sb-num">02</div>
+      <div class="sb-brand">DUCATI INDIA</div>
+      <div class="sb-cap">CAMPAIGN CREATIVE · 2018–20</div>
+    </div>
+    <div class="sb-tile">
+      <div class="sb-num">03</div>
+      <div class="sb-brand">WENDY'S INDIA</div>
+      <div class="sb-cap">LAUNCH CREATIVE · 2019–20</div>
+    </div>
+  </div>
+  <div class="sb-cap-row">↑ social booth · brand work · <em>placeholder — real assets to come</em></div>
+</div>
+
+<div class="col col-narrow prose">
+  <p>I joined Social Booth in 2016 as one of the founding creatives. Over four years I built and led the design team from zero to 8+, and led campaign and launch creative for Ford India, Ducati India, and the Wendy's India launch — three major brand campaigns in the Indian market.</p>
+
+  <p>I left in 2020. Three years later, the agency was acquired by VaynerMedia and rebranded as VaynerMedia India.</p>
+</div>
+
+<section class="chapter">
+  <div class="col col-narrow prose">
+    <div class="chapter-num">WHAT I LED</div>
+    <h2>four years, four pieces of work.</h2>
+
+    <ul class="sb-list">
+      <li>
+        <div class="sb-tag"><span class="n">01</span>THE DESIGN TEAM (0 → 8+)</div>
+        <div class="sb-body">Built design at Social Booth from a one-person creative function to an 8-person multidisciplinary team. Hired, mentored, ran creative reviews, set the studio's visual direction.</div>
+      </li>
+      <li>
+        <div class="sb-tag"><span class="n">02</span>FORD INDIA</div>
+        <div class="sb-body">Led campaign creative for Ford India during a high-stakes period of brand work in the Indian market.</div>
+      </li>
+      <li>
+        <div class="sb-tag"><span class="n">03</span>DUCATI INDIA</div>
+        <div class="sb-body">Led campaign creative for Ducati India — premium positioning work in a competitive premium-motorcycle segment.</div>
+      </li>
+      <li>
+        <div class="sb-tag"><span class="n">04</span>WENDY'S INDIA LAUNCH</div>
+        <div class="sb-body">Led launch creative for Wendy's entry into the Indian market. Launches are a different category of work from ongoing brand work — fixed dates, multi-stakeholder coordination, real commercial stakes from day one.</div>
+      </li>
+    </ul>
+  </div>
+</section>
+
+<section class="chapter">
+  <div class="col col-narrow prose">
+    <div class="chapter-num">WHAT THIS TAUGHT ME</div>
+    <h2>leadership is a different muscle.</h2>
+
+    <p>Creative leadership is a different muscle than IC craft. Building a team teaches you how to give people work that grows them, how to evaluate output without doing the work yourself, and how to hold a studio's standards across a portfolio of clients with different needs. The brand work — Ford, Ducati, Wendy's — taught me how to operate when the stakeholder list is long and every piece ships under public scrutiny.</p>
+
+    <p>I left the agency in 2020. The work I did there is part of why VaynerMedia eventually acquired it — but that acquisition is their story, not mine to claim. What I claim is the four years of building, leading, and shipping that came before it.</p>
+  </div>
+</section>
+
+<section class="cs-foot">
+  <div class="col col-narrow">
+    <div style="font-family:var(--font-mono);font-size:11px;letter-spacing:0.14em;text-transform:uppercase;color:var(--fg-dim)">END OF CASE STUDY · SOCIAL BOOTH · ARCHIVED</div>
+    <div class="next-up">
+      <a href="/work" class="nx">
+        <div class="label">← INDEX</div>
+        <div class="title">all work</div>
+      </a>
+    </div>
+  </div>
+</section>
+
+<script src="/site.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- new case study page at `/work/social-booth` covering 2016–2020 at social booth (foundational creative / head of design).
- matches existing case study structure (hero, breadcrumb, chapter sections, cs-foot) and uses shared tokens from `colors_and_type.css` + `case-study.css`.
- placeholder brand-work grid for ford / ducati / wendy's india with a `<!-- TODO: real brand work assets -->` note. renders cleanly without images.
- bottom nav links back to `/work` only (per ticket — index linking is a separate PR).

Closes RAG-4

## Test plan
- [ ] open `/work/social-booth` locally and confirm hero, breadcrumb, and chapter typography match `arqo` / `ef` / `zulily`.
- [ ] confirm placeholder tiles render with no broken image refs.
- [ ] confirm `[← all work]` returns to `/work`.
- [ ] confirm no other files changed (`git diff --stat origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)