### PR TITLE
about: rewrite with full arc + role criteria (RAG-9)

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,23 +14,37 @@
 <section class="page-hero">
   <div class="col">
     <div class="crumbs"><a href="/">home</a><span class="sep">/</span><span>about</span></div>
-    <h1>about.</h1>
-    <p class="lede">design engineer. brooklyn, by way of east delhi and mumbai. fifteen years of shipping inside other people's roadmaps; now mostly shipping inside my own.</p>
+    <h1>ABOUT</h1>
   </div>
 </section>
 
 <div class="col col-prose prose">
-  <p>I design and build the whole loop — discovery, the figma, the codebase, the shipped url, the post-launch instrumentation. The role most teams call <em>design engineer</em> or <em>design systems lead</em>; some call it <em>founding designer</em>. The label matters less than the loop.</p>
+  <p>i'm a design engineer. brooklyn. 13 years.</p>
 
-  <p>For the last three years I've been at <a href="/work/ef">EF World Journeys</a>, working on the booking surface — checkout, insurance, the quoting tool — and authoring two design frameworks (<a href="/work/mind">MIND</a> and <a href="/work/hcai">Designing for Humans</a>) that the org uses across surfaces. Before that, two years at Zulily on a personalization engine that sent 16M unique emails a day. Before that, four years as creative director at The Social Booth in Mumbai, running a 10-person team across 20+ enterprise clients including Ducati and Audi.</p>
+  <p>the arc, in order: agency creative direction in mumbai (2011–2020), ML personalization at zulily (2020–22), enterprise vertical SaaS at ef world journeys (2022–present), and solo product founding (2025–present, arqo).</p>
 
-  <p>On the side I'm building <a href="/work/jmnpr">JMNPR Labs</a> — a one-person tools studio, named for <em>Jamanapaar</em>, the other side of the Yamuna. <a href="/work/arqo">Arqo</a> is the consumer surface; five more flagships are on deck.</p>
+  <p>each chapter taught a different thing the next chapter needed. mumbai taught creative leadership and how to operate under deadline pressure with stakeholders who have opinions. zulily taught systems design at algorithm scale. EF taught conservative, high-stakes design where small UX shifts move millions in revenue. arqo is the test of whether all three can be carried in one person's hands at once.</p>
 
-  <h2>posture</h2>
-  <p>Self-serve over enterprise. Receipts over portfolios. Restraint over feature lists. The brand holds because of what it says no to.</p>
+  <p>the thesis: the combination is the moat. each axis at 80%+, each axis compounding with the others, each axis improving daily. agentic dev workflows as the multiplier — claude code, cursor, v0, custom MCP servers, autonomous agents running real ops in production.</p>
 
-  <h2>find me</h2>
-  <p>Email: <a href="mailto:work.raghavahuja@gmail.com" target="_blank" rel="noopener">work.raghavahuja@gmail.com</a>. ⌘K opens everything else.</p>
+  <p>a master of one will out-depth me in any single lane. across the lanes, the math changes.</p>
+
+  <figure>
+    <!-- TODO: real photo -->
+    <div class="placeholder">photo — raghav working</div>
+  </figure>
+
+  <h2>WHAT I'M LOOKING FOR</h2>
+  <p>staff or principal design engineer roles at later-stage tech. founding designer / founding design engineer roles at AI-native series A/B startups. NYC, or remote-US. open to head-of-design at lean (10-30) teams where the leadership history applies.</p>
+
+  <h2>WHAT I'M NOT LOOKING FOR</h2>
+  <p>pure design roles where the engineering is treated as a stretch. pure engineering roles where the design is treated as a stretch. companies that hire "design engineers" but really mean front-end developers who use figma occasionally. the combination is the job.</p>
+
+  <div class="ab-cta" style="display:flex; gap:14px; flex-wrap:wrap; margin-top: var(--s-5);">
+    <a href="/resume.pdf" class="btn btn-ghost">[ resume PDF → ]</a>
+    <a href="https://www.linkedin.com/in/raghavahuja/" target="_blank" rel="noopener" class="btn btn-ghost">[ linkedin → ]</a>
+    <a href="mailto:work.raghavahuja@gmail.com" class="btn btn-fill">[ email → work.raghavahuja@gmail.com ]</a>
+  </div>
 </div>
 
 <script src="/site.js"></script>


### PR DESCRIPTION
## Summary
- Replaced the thin /about body with the full arc (mumbai → zulily → EF → arqo) and the thesis paragraph.
- Added WHAT I'M LOOKING FOR and WHAT I'M NOT LOOKING FOR sections.
- Added CTA bar (resume PDF, linkedin, email mailto) and a figure placeholder for a real photo.
- Preserved head, nav slot, footer scripts, and existing class conventions (page-hero, prose, btn).

Closes RAG-9

## Test plan
- [ ] Visual check at /about — heading reads ABOUT, paragraphs lowercase as written
- [ ] CTA buttons: /resume.pdf, linkedin.com/in/raghavahuja/, mailto work.raghavahuja@gmail.com
- [ ] Photo figure renders the placeholder without breaking layout

Generated with Claude Code