### PR TITLE
work: /work index full inventory (RAG-12)

### DIFF
--- a/work/index.html
+++ b/work/index.html
@@ -58,7 +58,7 @@
 <section class="page-hero">
   <div class="col">
     <div class="crumbs"><a href="/">home</a><span class="sep">/</span><span>work</span></div>
-    <h1>work.</h1>
+    <h1>all work.</h1>
     <p class="lede">fifteen years of design engineering. a few things i'm allowed to talk about. the rest you'll have to email me for.</p>
     <p class="lede dim">written long. read what you need.</p>
   </div>
@@ -67,27 +67,65 @@
 <section class="wlist">
   <div class="col">
     <div class="filterbar">
-      <span class="on">ALL · 4</span>
-      <span>SHIPPED · 2</span>
+      <span class="on">ALL · 5</span>
+      <span>LIVE · 2</span>
       <span>GATED · 1</span>
+      <span>ACQUIRED · 1</span>
       <span>ARCHIVED · 1</span>
-      <span class="grow">SORTED BY YEAR ↓</span>
+      <span>ACTIVE · 1</span>
+      <span class="grow">FULL INVENTORY</span>
     </div>
 
     <a href="/work/arqo" class="wrow">
       <span class="num">001</span>
-      <span class="wm">2026 · SOLO</span>
+      <span class="wm">2025–26 · CO-FOUNDER / CTO</span>
       <div>
         <div class="wt">arqo</div>
         <div class="wd">mobile-first screenwriting. AST-as-OS, three synchronized views on the phone, shipped solo in nine days using an agentic-dev workflow.</div>
       </div>
       <span class="wm">CONTENTEDITABLE · CRDT · TAURI</span>
-      <span class="ws">SHIPPED</span>
+      <span class="ws">LIVE</span>
+      <span class="arrow">→</span>
+    </a>
+
+    <a href="/work/ef" class="wrow">
+      <span class="num">002</span>
+      <span class="wm">2022– · STAFF</span>
+      <div>
+        <div class="wt">EF world journeys</div>
+        <div class="wd">checkout rebuild. insurance redesign. quoting tool across 50+ countries. two design frameworks. gated — email for the password.</div>
+      </div>
+      <span class="wm">DESIGN SYS · GROWTH · AI</span>
+      <span class="ws gated">LIVE &amp; GATED ▼</span>
+      <span class="arrow">→</span>
+    </a>
+
+    <a href="/work/social-booth" class="wrow">
+      <span class="num">003</span>
+      <span class="wm">2016–20 · FOUNDATIONAL</span>
+      <div>
+        <div class="wt">social booth</div>
+        <div class="wd">photo-activation studio i started in mumbai. four years, then acquired in 2023.</div>
+      </div>
+      <span class="wm">STUDIO · OPS · BRAND</span>
+      <span class="ws archived">ACQUIRED 2023</span>
+      <span class="arrow">→</span>
+    </a>
+
+    <a href="/work/zulily" class="wrow">
+      <span class="num">004</span>
+      <span class="wm">2020–22 · GROWTH</span>
+      <div>
+        <div class="wt">zulily — 16M emails / day</div>
+        <div class="wd">algorithmic logic for a personalized email ecosystem. +14% CTR, +45s session, zero manual curation.</div>
+      </div>
+      <span class="wm">PERSONALIZATION · ML</span>
+      <span class="ws archived">ARCHIVED</span>
       <span class="arrow">→</span>
     </a>
 
     <a href="/work/jmnpr" class="wrow">
-      <span class="num">002</span>
+      <span class="num">005</span>
       <span class="wm">2025– · STUDIO</span>
       <div>
         <div class="wt">jmnpr labs</div>
@@ -98,29 +136,7 @@
       <span class="arrow">→</span>
     </a>
 
-    <a href="/work/ef" class="wrow">
-      <span class="num">003</span>
-      <span class="wm">2022– · STAFF</span>
-      <div>
-        <div class="wt">EF world journeys</div>
-        <div class="wd">checkout rebuild. insurance redesign. quoting tool across 50+ countries. two design frameworks. gated — email for the password.</div>
-      </div>
-      <span class="wm">DESIGN SYS · GROWTH · AI</span>
-      <span class="ws gated">GATED ▼</span>
-      <span class="arrow">→</span>
-    </a>
-
-    <a href="/work/zulily" class="wrow">
-      <span class="num">004</span>
-      <span class="wm">2021–22 · GROWTH</span>
-      <div>
-        <div class="wt">zulily — 16M emails / day</div>
-        <div class="wd">algorithmic logic for a personalized email ecosystem. +14% CTR, +45s session, zero manual curation.</div>
-      </div>
-      <span class="wm">PERSONALIZATION · ML</span>
-      <span class="ws archived">ARCHIVED</span>
-      <span class="arrow">→</span>
-    </a>
+    <!-- TODO: optional 006+ for older agency/freelance work -->
 
   </div>
 </section>


### PR DESCRIPTION
## Summary
- /work index now lists all 5 entries (arqo, ef, social-booth, zulily, jmnpr) in the required order with role + status columns
- statuses: LIVE, LIVE & GATED, ACQUIRED 2023, ARCHIVED, ACTIVE
- preserved existing wrow grid pattern, hover states, and lowercase voice
- left TODO comment for optional 006+ older agency/freelance block

Closes RAG-12

## Test plan
- [ ] visit /work — all 5 rows render in order 001 → 005
- [ ] each row navigates to its case study slug (/work/arqo, /work/ef, /work/social-booth, /work/zulily, /work/jmnpr)
- [ ] /work/social-booth resolves once the parallel case-study PR merges
- [ ] hover state (padding-left + heat color) works on all rows
- [ ] mobile layout collapses correctly under 980px

🤖 Generated with [Claude Code](https://claude.com/claude-code)