### PR TITLE
footer: sitewide resume/linkedin/email CTAs (RAG-14)

### DIFF
--- a/site.css
+++ b/site.css
@@ -215,6 +215,28 @@ body { margin: 0; }
   margin: var(--s-4) 0;
 }
 
+/* ---------- sitewide footer CTAs (injected by site.js) ---------- */
+.site-footer-ctas {
+  border-top: 1px solid var(--rule);
+  padding: var(--s-5) 0 var(--s-5);
+  background: var(--bg);
+}
+.site-footer-ctas .col {
+  display: flex; gap: 14px; flex-wrap: wrap;
+  align-items: center;
+}
+.site-footer-ctas a.btn {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: -0.01em;
+}
+@media (max-width: 640px) {
+  .site-footer-ctas .col {
+    flex-direction: column; align-items: stretch; gap: 10px;
+  }
+  .site-footer-ctas a.btn { justify-content: center; }
+}
+
 /* page hero */
 .page-hero {
   padding: var(--s-7) 0 var(--s-6);

--- a/site.js
+++ b/site.js
@@ -8,6 +8,22 @@
     wireTopbar();
   }
 
+  // --- 1b. Inject sitewide footer CTAs ---
+  // Single source of truth for resume / linkedin / email CTAs across every page that loads site.js.
+  // Skipped on the standalone "bulletin" pages (mamdani-mapper, hot-cold) — they don't load site.js.
+  if (!document.querySelector('.site-footer-ctas')) {
+    const ctaWrap = document.createElement('footer');
+    ctaWrap.className = 'site-footer-ctas';
+    ctaWrap.setAttribute('aria-label', 'site contact actions');
+    ctaWrap.innerHTML = `
+      <div class="col">
+        <a href="/resume.pdf" class="btn btn-ghost" target="_blank" rel="noopener">[ Resume PDF → ]</a>
+        <a href="https://www.linkedin.com/in/raghavahuja/" class="btn btn-ghost" target="_blank" rel="noopener">[ LinkedIn → ]</a>
+        <a href="mailto:work.raghavahuja@gmail.com" class="btn btn-ghost">[ Email → ]</a>
+      </div>`;
+    document.body.appendChild(ctaWrap);
+  }
+
   // --- 2. Dual clock ---
   function dualClock() {
     const fmt = (tz) => new Intl.DateTimeFormat('en-GB', { hour:'2-digit', minute:'2-digit', hour12:false, timeZone:tz }).format(new Date());


### PR DESCRIPTION
## Summary
- Add a sitewide footer CTA bar with three monospace bracket buttons: `[ Resume PDF → ]`, `[ LinkedIn → ]`, `[ Email → ]`.
- Implemented via `site.js` injection so it appears on every page that loads the shared chrome — single source of truth, no per-page HTML edits.
- Styles live in `site.css` under `.site-footer-ctas`, reusing the existing `.btn .btn-ghost` mono treatment already used on `/about`. Stacks vertically below 640px.

## Notes
- Standalone "bulletin" pages (`hot-cold.html`, `mamdani-mapper.html`) intentionally do not load `site.js` and keep their bespoke footers, per the existing comment in `receipts/mamdani-mapper.html`. They're not in scope for sitewide chrome.
- The bar is appended at end of `<body>`, so on `index.html` it sits below the existing conversational `<footer class="text-msg">` colophon — additive, no semantics changed on existing footer links.
- Bracket labels are rendered as literal text inside the link (matching the precedent on `/about`), not via `::before/::after`.

## Test plan
- [ ] Serve locally (`python3 -m http.server`) and click through `/`, `/about`, `/work`, `/work/arqo`, `/receipts`, `/now`, `/stack`, `/contact`, `/404.html` — CTA bar visible at the bottom on each.
- [ ] Resume opens `/resume.pdf` in a new tab.
- [ ] LinkedIn opens the correct profile in a new tab.
- [ ] Email triggers `mailto:work.raghavahuja@gmail.com`.
- [ ] On a narrow viewport (<640px) the three CTAs stack vertically.
- [ ] `hot-cold.html` and `mamdani-mapper.html` remain unchanged (bespoke footers).

Closes RAG-14

🤖 Generated with [Claude Code](https://claude.com/claude-code)